### PR TITLE
feat: expand embedding provider and vectorstore matrix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,21 +2,64 @@
 # movie-finder-rag — Docker-only local development environment template
 #
 # Copy to `.env` before running any `make ...` target.
-# This repo is the only local-development flow that uses the write-capable
-# Qdrant key. Qdrant is external-only; do not use localhost endpoints here.
+# All repo workflows run through Docker Compose; do not depend on host Python.
+# Remote vector stores should use routable service endpoints, not localhost.
+# If Ollama is selected, `OLLAMA_URL` must be reachable from inside Docker.
 # =============================================================================
 
+# --- Provider factory --------------------------------------------------------
+# EMBEDDING_PROVIDER: openai | ollama | huggingface | sentence-transformers | google
+# WITH_PROVIDERS: set to `local` to install heavy local-provider dependencies in Docker.
+WITH_PROVIDERS=
+EMBEDDING_PROVIDER=openai
+EMBEDDING_MODEL=text-embedding-3-large
+# Optional reduced output dimension for providers that support it (OpenAI, Ollama, HF truncate).
+EMBEDDING_DIMENSIONS=
+
 # --- Qdrant Cloud ------------------------------------------------------------
-# Canonical contract from movie-finder#35 / infrastructure#8:
+# Canonical remote contract when VECTOR_STORE=qdrant:
 #   QDRANT_URL
 #   QDRANT_API_KEY_RW
-#   QDRANT_COLLECTION_NAME
+#   QDRANT_COLLECTION_PREFIX
 QDRANT_URL=https://your-cluster.qdrant.io
 QDRANT_API_KEY_RW=
-QDRANT_COLLECTION_NAME=movies
+# ADR 0008 contract: final collection is {QDRANT_COLLECTION_PREFIX}_{sanitized_model}_{dimension}
+QDRANT_COLLECTION_PREFIX=movies
 
-# --- OpenAI embeddings -------------------------------------------------------
+# --- Vector store selection --------------------------------------------------
+# VECTOR_STORE: qdrant | chromadb | pinecone | pgvector
+VECTOR_STORE=qdrant
+VECTOR_STORE_URL=
+VECTOR_STORE_API_KEY=
+CHROMADB_PERSIST_PATH=outputs/chromadb/local
+
+# Pinecone serverless settings
+PINECONE_API_KEY=
+PINECONE_INDEX_NAME=movie-finder-rag
+PINECONE_INDEX_HOST=
+PINECONE_CLOUD=aws
+PINECONE_REGION=us-east-1
+
+# PGVector settings
+PGVECTOR_DSN=
+PGVECTOR_SCHEMA=public
+
+# --- Provider credentials ----------------------------------------------------
 OPENAI_API_KEY=sk-
+GOOGLE_API_KEY=
+
+# Ollama must be reachable from inside Docker, for example another Compose service
+# on the same network or a remote Ollama endpoint.
+OLLAMA_URL=http://ollama:11434
+# Set when using Ollama cloud at https://ollama.com/api
+OLLAMA_API_KEY=
+
+# HuggingFace / sentence-transformers local cache
+SENTENCE_TRANSFORMERS_CACHE_DIR=
+
+# --- Validation and backup ---------------------------------------------------
+# Used by `make validate` after ingestion smoke tests.
+VALIDATION_QUERY=A time-travel movie with a scientist and a DeLorean
 
 # --- Kaggle dataset download -------------------------------------------------
 KAGGLE_API_TOKEN=KGAT_

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,15 +1,19 @@
 # GitHub Copilot — movie-finder-rag
 
-Offline embedding ingestion pipeline — downloads Kaggle movie data, generates OpenAI embeddings, and upserts into Qdrant Cloud.
+Offline embedding ingestion pipeline — downloads Kaggle movie data, generates embeddings through the
+ADR 0008 factory, and writes vectors into the configured backend.
 
 > For full project context, persona prompts, and architecture reference: see root `.github/copilot-instructions.md`.
+
+Docker-only repo contract still applies here. Do not propose host-Python workflows or localhost-only
+service assumptions when editing this submodule.
 
 ---
 
 ## Python standards
 
 - `ruff` rules in scope: E, W, F, I, B, UP (E501 and B008 are ignored)
-- Tests must stub OpenAI, Qdrant, and Kaggle interactions — no real API calls in tests
+- Tests must stub provider, vector store, and Kaggle interactions — no real API calls in tests
 - Every new embedding provider or pipeline step needs test coverage
 - Run `make help` for all available targets
 
@@ -22,7 +26,7 @@ Offline embedding ingestion pipeline — downloads Kaggle movie data, generates 
 | Pattern                  | Rule                                                                                                                          |
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
 | **Strategy**             | New embedding provider = new class implementing the embedding interface. Never add `if provider == "openai":` in the ingestion loop. |
-| **Strategy**             | `qdrant` and `chromadb` are strategies behind a common vector store interface. Add new stores the same way.                   |
+| **Strategy**             | `qdrant`, `chromadb`, `pinecone`, and `pgvector` are strategies behind a common vector store interface. Add new stores the same way. |
 | **Factory**              | Provider objects are created in one place (entrypoint/factory function), not scattered through pipeline steps.                |
 | **Configuration object** | All env vars loaded once in `config.py` via Pydantic `BaseSettings`. Never call `os.getenv()` inside pipeline functions.     |
 
@@ -34,6 +38,6 @@ Offline embedding ingestion pipeline — downloads Kaggle movie data, generates 
 | ------------------- | ------------------------------------------------------------------------- |
 | `config.py`         | Pydantic `BaseSettings` — single source for all env vars                  |
 | `Makefile`          | Docker-only dev contract — run `make help` for all targets                |
-| `docker-compose.yml` | Local `rag` container (Qdrant is always external — never local)          |
-| `Jenkinsfile`       | CI pipeline — triggered manually or on `main`/tags via `RUN_INGESTION`   |
-| `.env.example`      | Required vars: `QDRANT_URL`, `QDRANT_API_KEY_RW`, `QDRANT_COLLECTION_NAME`, `OPENAI_API_KEY`, `KAGGLE_API_TOKEN` |
+| `docker-compose.yml` | Local `rag` container; Docker is the only supported execution path      |
+| `Jenkinsfile`       | CI pipeline for provider/store matrix runs and artifact archiving        |
+| `.env.example`      | Canonical provider/store configuration template                         |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
     tags: ['v*']
@@ -130,6 +131,7 @@ jobs:
   # -------------------------------------------------------------------------- #
   lint:
     name: Lint
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     env:
       WITH_PROVIDERS: ${{ github.event.inputs.with_providers || '' }}
@@ -146,6 +148,7 @@ jobs:
   # -------------------------------------------------------------------------- #
   typecheck:
     name: Typecheck
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     env:
       WITH_PROVIDERS: ${{ github.event.inputs.with_providers || '' }}
@@ -162,6 +165,7 @@ jobs:
   # -------------------------------------------------------------------------- #
   test:
     name: Test
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -186,7 +190,7 @@ jobs:
           files: reports/junit.xml
 
       - name: Generate coverage summary
-        if: always()
+        if: always() && hashFiles('reports/coverage.xml') != ''
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
           filename: reports/coverage.xml
@@ -200,7 +204,7 @@ jobs:
           thresholds: '10 80'
 
       - name: Post coverage comment
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && hashFiles('code-coverage-results.md') != ''
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           recreate: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,34 @@
 # =============================================================================
 # movie-finder-rag — GitHub Actions CI
 #
-# Mirrors the Jenkins Multibranch pipeline 1:1.
-# Both pipelines must remain in sync. Changes to build logic must be applied
-# to both Jenkinsfile and this file.
+# Mirrors the Jenkins pipeline contract for Docker-only execution.
+# Both pipelines should stay logically aligned even if their parameter surfaces
+# differ slightly to fit each CI system.
 #
 # Modes:
 #   Contribution   — PR + main pushes: Lint · Typecheck · Test
 #   Manual ops     — workflow_dispatch with run_ingestion/run_backup:
-#                    Lint · Typecheck · Test · optional ingest/backup against live vector store
+#                    Lint · Typecheck · Test · optional ingest · validate · backup
 #
-# Required GitHub Actions secrets (manual ops only):
-#   QDRANT_URL          Qdrant Cloud endpoint
-#   QDRANT_API_KEY_RW   Read-write API key
-#   OPENAI_API_KEY      For embedding model
-#   KAGGLE_API_TOKEN    For dataset download (JSON string)
+# Docker-only contract:
+# - All quality and ops commands execute through `make ...`.
+# - Localhost assumptions are not part of the supported workflow.
+# - If Ollama is used, its URL must be reachable from inside the job container.
+#
+# Manual-ops secrets:
+#   OPENAI_API_KEY
+#   GOOGLE_API_KEY
+#   OLLAMA_API_KEY
+#   QDRANT_URL
+#   QDRANT_API_KEY_RW
+#   PINECONE_API_KEY
+#   PGVECTOR_DSN
+#   KAGGLE_API_TOKEN
+#
+# Artifact contract:
+# - Ingestion emits `ingestion-outputs.env` and `outputs/reports/cost-report.json`.
+# - Validation emits `outputs/reports/validation-report.json`.
+# - Backup emits a portable ChromaDB artifact under `outputs/backups/**`.
 # =============================================================================
 
 name: CI
@@ -30,32 +44,94 @@ on:
       run_ingestion:
         type: boolean
         default: false
-        description: Run the offline ingestion pipeline against Qdrant Cloud.
+        description: Run the offline ingestion pipeline against the configured vector store.
       run_backup:
         type: boolean
         default: false
         description: Run the backup utility against the configured live vector store.
+      embedding_provider:
+        type: choice
+        default: openai
+        options:
+          - openai
+          - ollama
+          - huggingface
+          - sentence-transformers
+          - google
+        description: ADR 0008 embedding provider selection.
+      embedding_model:
+        type: string
+        default: text-embedding-3-large
+        description: Provider-specific embedding model identifier.
+      embedding_dimensions:
+        type: string
+        default: ''
+        description: Optional output dimension override.
+      with_providers:
+        type: string
+        default: ''
+        description: Docker build extra groups, for example `local`.
       vector_store:
         type: choice
         default: qdrant
         options:
           - qdrant
-        description: Vector store type for the backup utility.
-      collection_name:
+          - chromadb
+          - pinecone
+          - pgvector
+        description: Vector store backend for ingestion, validation, and backup.
+      collection_prefix:
         type: string
         default: movies
-        description: Collection name to ingest and/or back up.
+        description: Prefix used to derive the ADR 0008 target name during ingestion.
+      collection_name:
+        type: string
+        default: ''
+        description: Concrete target name for backup-only runs when ingestion is skipped.
+      validation_query:
+        type: string
+        default: A time-travel movie with a scientist and a DeLorean
+        description: Smoke-test query for post-ingest validation.
+      ollama_url:
+        type: string
+        default: http://ollama:11434
+        description: Docker-reachable Ollama base URL.
+      chromadb_persist_path:
+        type: string
+        default: outputs/chromadb/local
+        description: Persistent path for chromadb ingestion and backup.
+      pinecone_index_name:
+        type: string
+        default: movie-finder-rag
+        description: Pinecone index name when vector_store=pinecone.
+      pinecone_index_host:
+        type: string
+        default: ''
+        description: Optional Pinecone host override.
+      pinecone_cloud:
+        type: string
+        default: aws
+        description: Pinecone serverless cloud used for index creation.
+      pinecone_region:
+        type: string
+        default: us-east-1
+        description: Pinecone serverless region used for index creation.
+      pgvector_schema:
+        type: string
+        default: public
+        description: Schema token used when vector_store=pgvector.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-
   # -------------------------------------------------------------------------- #
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    env:
+      WITH_PROVIDERS: ${{ github.event.inputs.with_providers || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -70,6 +146,8 @@ jobs:
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
+    env:
+      WITH_PROVIDERS: ${{ github.event.inputs.with_providers || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -88,6 +166,8 @@ jobs:
       checks: write
       pull-requests: write
       contents: read
+    env:
+      WITH_PROVIDERS: ${{ github.event.inputs.with_providers || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -139,11 +219,28 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.run_ingestion == 'true'
     env:
+      WITH_PROVIDERS: ${{ github.event.inputs.with_providers || '' }}
+      VECTOR_STORE: ${{ github.event.inputs.vector_store || 'qdrant' }}
+      QDRANT_COLLECTION_PREFIX: ${{ github.event.inputs.collection_prefix || 'movies' }}
+      EMBEDDING_PROVIDER: ${{ github.event.inputs.embedding_provider || 'openai' }}
+      EMBEDDING_MODEL: ${{ github.event.inputs.embedding_model || 'text-embedding-3-large' }}
+      EMBEDDING_DIMENSIONS: ${{ github.event.inputs.embedding_dimensions || '' }}
+      VALIDATION_QUERY: ${{ github.event.inputs.validation_query || 'A time-travel movie with a scientist and a DeLorean' }}
+      OLLAMA_URL: ${{ github.event.inputs.ollama_url || 'http://ollama:11434' }}
+      CHROMADB_PERSIST_PATH: ${{ github.event.inputs.chromadb_persist_path || 'outputs/chromadb/local' }}
+      PINECONE_INDEX_NAME: ${{ github.event.inputs.pinecone_index_name || 'movie-finder-rag' }}
+      PINECONE_INDEX_HOST: ${{ github.event.inputs.pinecone_index_host || '' }}
+      PINECONE_CLOUD: ${{ github.event.inputs.pinecone_cloud || 'aws' }}
+      PINECONE_REGION: ${{ github.event.inputs.pinecone_region || 'us-east-1' }}
+      PGVECTOR_SCHEMA: ${{ github.event.inputs.pgvector_schema || 'public' }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
       QDRANT_URL: ${{ secrets.QDRANT_URL }}
       QDRANT_API_KEY_RW: ${{ secrets.QDRANT_API_KEY_RW }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+      PGVECTOR_DSN: ${{ secrets.PGVECTOR_DSN }}
       KAGGLE_API_TOKEN: ${{ secrets.KAGGLE_API_TOKEN }}
-      QDRANT_COLLECTION_NAME: ${{ github.event.inputs.collection_name || 'movies' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -159,26 +256,90 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ingestion-outputs
-          path: ingestion-outputs.env
+          path: |
+            ingestion-outputs.env
+            outputs/reports/cost-report.json
+          if-no-files-found: ignore
+
+  # -------------------------------------------------------------------------- #
+  validate:
+    name: Validate
+    needs: [lint, typecheck, test, ingest]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.run_ingestion == 'true'
+    env:
+      WITH_PROVIDERS: ${{ github.event.inputs.with_providers || '' }}
+      VECTOR_STORE: ${{ github.event.inputs.vector_store || 'qdrant' }}
+      QDRANT_COLLECTION_PREFIX: ${{ github.event.inputs.collection_prefix || 'movies' }}
+      EMBEDDING_PROVIDER: ${{ github.event.inputs.embedding_provider || 'openai' }}
+      EMBEDDING_MODEL: ${{ github.event.inputs.embedding_model || 'text-embedding-3-large' }}
+      EMBEDDING_DIMENSIONS: ${{ github.event.inputs.embedding_dimensions || '' }}
+      VALIDATION_QUERY: ${{ github.event.inputs.validation_query || 'A time-travel movie with a scientist and a DeLorean' }}
+      OLLAMA_URL: ${{ github.event.inputs.ollama_url || 'http://ollama:11434' }}
+      CHROMADB_PERSIST_PATH: ${{ github.event.inputs.chromadb_persist_path || 'outputs/chromadb/local' }}
+      PINECONE_INDEX_NAME: ${{ github.event.inputs.pinecone_index_name || 'movie-finder-rag' }}
+      PINECONE_INDEX_HOST: ${{ github.event.inputs.pinecone_index_host || '' }}
+      PINECONE_CLOUD: ${{ github.event.inputs.pinecone_cloud || 'aws' }}
+      PINECONE_REGION: ${{ github.event.inputs.pinecone_region || 'us-east-1' }}
+      PGVECTOR_SCHEMA: ${{ github.event.inputs.pgvector_schema || 'public' }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+      QDRANT_URL: ${{ secrets.QDRANT_URL }}
+      QDRANT_API_KEY_RW: ${{ secrets.QDRANT_API_KEY_RW }}
+      PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+      PGVECTOR_DSN: ${{ secrets.PGVECTOR_DSN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize
+        run: make init
+
+      - name: Run validation
+        run: make validate
+
+      - name: Upload validation artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-results
+          path: outputs/reports/validation-report.json
           if-no-files-found: ignore
 
   # -------------------------------------------------------------------------- #
   backup:
     name: Backup
-    needs: [lint, typecheck, test, ingest]
+    needs: [lint, typecheck, test, ingest, validate]
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' &&
       (github.event.inputs.run_backup == 'true' || github.event.inputs.run_ingestion == 'true') &&
-      (needs.ingest.result == 'success' || needs.ingest.result == 'skipped')
+      (needs.ingest.result == 'success' || needs.ingest.result == 'skipped') &&
+      (needs.validate.result == 'success' || needs.validate.result == 'skipped')
     env:
+      WITH_PROVIDERS: ${{ github.event.inputs.with_providers || '' }}
       VECTOR_STORE: ${{ github.event.inputs.vector_store || 'qdrant' }}
-      BACKUP_COLLECTION_NAME: ${{ github.event.inputs.collection_name || 'movies' }}
-      BACKUP_OUTPUT_ROOT: outputs/backups/chromadb
-      VECTOR_STORE_URL: ${{ secrets.QDRANT_URL }}
-      VECTOR_STORE_API_KEY: ${{ secrets.QDRANT_API_KEY_RW }}
+      BACKUP_COLLECTION_NAME: ${{ github.event.inputs.collection_name || '' }}
+      BACKUP_OUTPUT_ROOT: outputs/backups
+      QDRANT_COLLECTION_PREFIX: ${{ github.event.inputs.collection_prefix || 'movies' }}
+      EMBEDDING_PROVIDER: ${{ github.event.inputs.embedding_provider || 'openai' }}
+      EMBEDDING_MODEL: ${{ github.event.inputs.embedding_model || 'text-embedding-3-large' }}
+      EMBEDDING_DIMENSIONS: ${{ github.event.inputs.embedding_dimensions || '' }}
+      OLLAMA_URL: ${{ github.event.inputs.ollama_url || 'http://ollama:11434' }}
+      CHROMADB_PERSIST_PATH: ${{ github.event.inputs.chromadb_persist_path || 'outputs/chromadb/local' }}
+      PINECONE_INDEX_NAME: ${{ github.event.inputs.pinecone_index_name || 'movie-finder-rag' }}
+      PINECONE_INDEX_HOST: ${{ github.event.inputs.pinecone_index_host || '' }}
+      PINECONE_CLOUD: ${{ github.event.inputs.pinecone_cloud || 'aws' }}
+      PINECONE_REGION: ${{ github.event.inputs.pinecone_region || 'us-east-1' }}
+      PGVECTOR_SCHEMA: ${{ github.event.inputs.pgvector_schema || 'public' }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
       QDRANT_URL: ${{ secrets.QDRANT_URL }}
       QDRANT_API_KEY_RW: ${{ secrets.QDRANT_API_KEY_RW }}
+      PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+      PGVECTOR_DSN: ${{ secrets.PGVECTOR_DSN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@
 #   KAGGLE_API_TOKEN
 #
 # Artifact contract:
-# - Ingestion emits `ingestion-outputs.env` and `outputs/reports/cost-report.json`.
+# - Ingestion emits `ingestion-outputs.env`, `outputs/reports/cost-report.json`,
+#   and `outputs/reports/skipped-movies.json`.
 # - Validation emits `outputs/reports/validation-report.json`.
 # - Backup emits a portable ChromaDB artifact under `outputs/backups/**`.
 # =============================================================================
@@ -259,6 +260,7 @@ jobs:
           path: |
             ingestion-outputs.env
             outputs/reports/cost-report.json
+            outputs/reports/skipped-movies.json
           if-no-files-found: ignore
 
   # -------------------------------------------------------------------------- #

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ chroma/
 # OS
 .DS_Store
 Thumbs.db
+.gitdir

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ outputs/
 # Logs
 logs/
 *.log
+ingestion-outputs.env
 
 # Dataset (large files — download via kagglehub, never commit)
 /dataset/

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -1,6 +1,6 @@
 # JetBrains AI (Junie) — rag_ingestion submodule guidelines
 
-This is **`movie-finder-rag`** (`backend/rag_ingestion/`) — Offline embedding ingestion pipeline.
+This is **`movie-finder-rag`** (`rag/`) — Offline embedding ingestion pipeline.
 GitHub repo: `aharbii/movie-finder-rag` · Parent: `aharbii/movie-finder`
 
 ---

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,16 +127,25 @@
     }
   ],
   "results": {
+    "CONTRIBUTING.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "CONTRIBUTING.md",
+        "hashed_secret": "eedbde13d0baad04070dea253214aae4826b044e",
+        "is_verified": true,
+        "line_number": 207
+      }
+    ],
     "tests/test_rag.py": [
       {
         "type": "Secret Keyword",
         "filename": "tests/test_rag.py",
         "hashed_secret": "676672e6cadc4959a8b78004d9aee44c55b49cb9",
         "is_verified": true,
-        "line_number": 33,
+        "line_number": 32,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-04-04T11:01:26Z"
+  "generated_at": "2026-04-20T20:37:11Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -136,15 +136,6 @@
         "line_number": 207
       }
     ],
-    "Jenkinsfile": [
-      {
-        "type": "Secret Keyword",
-        "filename": "Jenkinsfile",
-        "hashed_secret": "c267b646441a206d44803d8cb20896c4a166cac2",
-        "is_verified": false,
-        "line_number": 354
-      }
-    ],
     "tests/conftest.py": [
       {
         "type": "Secret Keyword",
@@ -172,5 +163,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-25T17:23:07Z"
+  "generated_at": "2026-04-25T17:30:03Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -136,6 +136,31 @@
         "line_number": 207
       }
     ],
+    "Jenkinsfile": [
+      {
+        "type": "Secret Keyword",
+        "filename": "Jenkinsfile",
+        "hashed_secret": "c267b646441a206d44803d8cb20896c4a166cac2",
+        "is_verified": false,
+        "line_number": 351
+      }
+    ],
+    "tests/conftest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/conftest.py",
+        "hashed_secret": "a28b2c550a06ab6d4fe1cdb5dd8d07693ec670ad",
+        "is_verified": false,
+        "line_number": 9
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/conftest.py",
+        "hashed_secret": "75ddfb45216fe09680dfe70eda4f559a910c832c",
+        "is_verified": false,
+        "line_number": 11
+      }
+    ],
     "tests/test_rag.py": [
       {
         "type": "Secret Keyword",
@@ -147,5 +172,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-20T20:37:11Z"
+  "generated_at": "2026-04-25T17:20:28Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -142,7 +142,7 @@
         "filename": "Jenkinsfile",
         "hashed_secret": "c267b646441a206d44803d8cb20896c4a166cac2",
         "is_verified": false,
-        "line_number": 351
+        "line_number": 354
       }
     ],
     "tests/conftest.py": [
@@ -172,5 +172,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-25T17:20:28Z"
+  "generated_at": "2026-04-25T17:23:07Z"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
 # =============================================================================
 # movie-finder-rag — Docker-only local development and runtime images
-#
-# Targets:
-#   dev      Attached-container image used by docker-compose.yml and VS Code
-#   builder  Intermediate dependency synchronization stage
-#   runtime  One-shot ingestion image used by Jenkins and `make ingest`
 # =============================================================================
 
 FROM python:3.13-slim AS uv-base
@@ -16,8 +11,9 @@ ENV PYTHONUNBUFFERED=1 \
     UV_LINK_MODE=copy
 
 
-# ---- Stage 1: dev -----------------------------------------------------------
 FROM uv-base AS dev
+
+ARG WITH_PROVIDERS=""
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
@@ -37,26 +33,34 @@ ENV PATH="/opt/venv/bin:$PATH" \
 COPY pyproject.toml uv.lock ./
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --all-groups --active --no-install-project --no-install-workspace
+    if [ -n "$WITH_PROVIDERS" ]; then \
+        uv sync --all-groups --extra "$WITH_PROVIDERS" --active --no-install-project --no-install-workspace; \
+    else \
+        uv sync --all-groups --active --no-install-project --no-install-workspace; \
+    fi
 
 CMD ["sleep", "infinity"]
 
 
-# ---- Stage 2: builder -------------------------------------------------------
 FROM uv-base AS builder
+
+ARG WITH_PROVIDERS=""
 
 WORKDIR /build
 
 COPY pyproject.toml uv.lock ./
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --no-install-project --no-install-workspace
+    if [ -n "$WITH_PROVIDERS" ]; then \
+        uv sync --frozen --no-dev --extra "$WITH_PROVIDERS" --no-install-project --no-install-workspace; \
+    else \
+        uv sync --frozen --no-dev --no-install-project --no-install-workspace; \
+    fi
 
 COPY src/ src/
 COPY scripts/ scripts/
 
 
-# ---- Stage 3: runtime -------------------------------------------------------
 FROM python:3.13-slim AS runtime
 
 LABEL org.opencontainers.image.title="movie-finder-rag"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,10 +7,6 @@
 //   Manual ops     — "Build with Parameters" with RUN_INGESTION/RUN_BACKUP=true:
 //                    Lint + Typecheck + Test + optional ingest + validate + backup
 //
-// Repo-side guards also skip draft PRs and non-main branch jobs. The Jenkins
-// multibranch source should still be configured to discover only main + PRs;
-// these guards prevent expensive work if Jenkins indexes extra branches.
-//
 // NOTE: This image is NOT pushed to ACR. The rag pipeline is an offline
 // one-shot ingestion tool run manually. Only backend and frontend images are
 // published to ACR.
@@ -158,23 +154,7 @@ pipeline {
 
     stages {
         // ------------------------------------------------------------------ //
-        stage('CI Eligibility') {
-            steps {
-                script {
-                    if (shouldRunPipeline()) {
-                        echo "RAG CI enabled for ${env.CHANGE_ID ? "PR-${env.CHANGE_ID}" : env.BRANCH_NAME}."
-                    } else {
-                        echo "RAG CI skipped for ${env.CHANGE_ID ? "draft PR-${env.CHANGE_ID}" : "branch ${env.BRANCH_NAME}"}."
-                    }
-                }
-            }
-        }
-
-        // ------------------------------------------------------------------ //
         stage('Initialize') {
-            when {
-                expression { shouldRunPipeline() }
-            }
             steps {
                 script {
                     env.WITH_PROVIDERS = params.WITH_PROVIDERS ?: ''
@@ -185,9 +165,6 @@ pipeline {
 
         // ------------------------------------------------------------------ //
         stage('Lint + Typecheck') {
-            when {
-                expression { shouldRunPipeline() }
-            }
             parallel {
                 stage('Lint') {
                     steps { sh 'make lint' }
@@ -200,9 +177,6 @@ pipeline {
 
         // ------------------------------------------------------------------ //
         stage('Test') {
-            when {
-                expression { shouldRunPipeline() }
-            }
             steps {
                 sh 'make test-coverage'
             }
@@ -228,7 +202,7 @@ pipeline {
         // ------------------------------------------------------------------ //
         stage('Ingest') {
             when {
-                expression { shouldRunPipeline() && params.RUN_INGESTION == true }
+                expression { params.RUN_INGESTION == true }
             }
             environment {
                 QDRANT_URL        = credentials('qdrant-url')
@@ -251,7 +225,7 @@ pipeline {
         // ------------------------------------------------------------------ //
         stage('Post-Ingest Validate') {
             when {
-                expression { shouldRunPipeline() && params.RUN_INGESTION == true }
+                expression { params.RUN_INGESTION == true }
             }
             environment {
                 QDRANT_URL        = credentials('qdrant-url')
@@ -273,9 +247,7 @@ pipeline {
         // ------------------------------------------------------------------ //
         stage('Backup') {
             when {
-                expression {
-                    shouldRunPipeline() && (params.RUN_BACKUP == true || params.RUN_INGESTION == true)
-                }
+                expression { params.RUN_BACKUP == true || params.RUN_INGESTION == true }
             }
             environment {
                 QDRANT_URL        = credentials('qdrant-url')
@@ -297,9 +269,7 @@ pipeline {
         // ------------------------------------------------------------------ //
         stage('Archive Artifacts') {
             when {
-                expression {
-                    shouldRunPipeline() && (params.RUN_INGESTION == true || params.RUN_BACKUP == true)
-                }
+                expression { params.RUN_INGESTION == true || params.RUN_BACKUP == true }
             }
             steps {
                 archiveArtifacts(
@@ -312,71 +282,9 @@ pipeline {
 
     post {
         always {
-            script {
-                if (shouldRunPipeline()) {
-                    sh 'make clean || true'
-                    sh 'make ci-down || true'
-                } else {
-                    echo 'Skipping Docker cleanup because no RAG CI stages ran.'
-                }
-                cleanWs()
-            }
-        }
-    }
-}
-
-// -------------------------------------------------------------------------- //
-def shouldRunPipeline() {
-    if (env.RAG_CI_ELIGIBLE?.trim()) {
-        return env.RAG_CI_ELIGIBLE == 'true'
-    }
-
-    def eligible = resolvePipelineEligibility()
-    env.RAG_CI_ELIGIBLE = eligible.toString()
-    return eligible
-}
-
-// -------------------------------------------------------------------------- //
-def resolvePipelineEligibility() {
-    if (env.CHANGE_ID) {
-        return !isDraftPullRequest()
-    }
-
-    return env.BRANCH_NAME == 'main'
-}
-
-// -------------------------------------------------------------------------- //
-def isDraftPullRequest() {
-    withCredentials([
-        usernamePassword(
-            credentialsId: 'github-pat',
-            usernameVariable: 'GITHUB_USER',
-            passwordVariable: 'GITHUB_TOKEN'
-        )
-    ]) {
-        withEnv(["PR_NUMBER=${env.CHANGE_ID}"]) {
-            def draft = sh(
-                script: '''
-                    set +x
-                    python3 - <<'PY'
-import json
-import os
-import urllib.request
-
-request = urllib.request.Request(
-    f"https://api.github.com/repos/aharbii/movie-finder-rag/pulls/{os.environ['PR_NUMBER']}",
-    headers={
-        "Accept": "application/vnd.github+json",
-        "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
-    },
-)
-with urllib.request.urlopen(request, timeout=20) as response:
-    print(str(bool(json.load(response).get("draft"))).lower())
-PY
-                ''',
-                returnStdout: true,
-            ).trim()
-            return draft == 'true'
+            sh 'make clean || true'
+            sh 'make ci-down || true'
+            cleanWs()
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,10 @@
 //   Manual ops     — "Build with Parameters" with RUN_INGESTION/RUN_BACKUP=true:
 //                    Lint + Typecheck + Test + optional ingest + validate + backup
 //
+// Repo-side guards also skip draft PRs and non-main branch jobs. The Jenkins
+// multibranch source should still be configured to discover only main + PRs;
+// these guards prevent expensive work if Jenkins indexes extra branches.
+//
 // NOTE: This image is NOT pushed to ACR. The rag pipeline is an offline
 // one-shot ingestion tool run manually. Only backend and frontend images are
 // published to ACR.
@@ -33,6 +37,8 @@
 //
 // Required Jenkins plugins: Docker Pipeline, JUnit, Coverage, Credentials Binding
 // =============================================================================
+
+def pipelineEligibility = null
 
 pipeline {
     agent any
@@ -154,7 +160,23 @@ pipeline {
 
     stages {
         // ------------------------------------------------------------------ //
+        stage('CI Eligibility') {
+            steps {
+                script {
+                    if (shouldRunPipeline()) {
+                        echo "RAG CI enabled for ${env.CHANGE_ID ? "PR-${env.CHANGE_ID}" : env.BRANCH_NAME}."
+                    } else {
+                        echo "RAG CI skipped for ${env.CHANGE_ID ? "draft PR-${env.CHANGE_ID}" : "branch ${env.BRANCH_NAME}"}."
+                    }
+                }
+            }
+        }
+
+        // ------------------------------------------------------------------ //
         stage('Initialize') {
+            when {
+                expression { shouldRunPipeline() }
+            }
             steps {
                 script {
                     env.WITH_PROVIDERS = params.WITH_PROVIDERS ?: ''
@@ -165,6 +187,9 @@ pipeline {
 
         // ------------------------------------------------------------------ //
         stage('Lint + Typecheck') {
+            when {
+                expression { shouldRunPipeline() }
+            }
             parallel {
                 stage('Lint') {
                     steps { sh 'make lint' }
@@ -177,6 +202,9 @@ pipeline {
 
         // ------------------------------------------------------------------ //
         stage('Test') {
+            when {
+                expression { shouldRunPipeline() }
+            }
             steps {
                 sh 'make test-coverage'
             }
@@ -202,7 +230,7 @@ pipeline {
         // ------------------------------------------------------------------ //
         stage('Ingest') {
             when {
-                expression { params.RUN_INGESTION == true }
+                expression { shouldRunPipeline() && params.RUN_INGESTION == true }
             }
             environment {
                 QDRANT_URL        = credentials('qdrant-url')
@@ -225,7 +253,7 @@ pipeline {
         // ------------------------------------------------------------------ //
         stage('Post-Ingest Validate') {
             when {
-                expression { params.RUN_INGESTION == true }
+                expression { shouldRunPipeline() && params.RUN_INGESTION == true }
             }
             environment {
                 QDRANT_URL        = credentials('qdrant-url')
@@ -247,7 +275,9 @@ pipeline {
         // ------------------------------------------------------------------ //
         stage('Backup') {
             when {
-                expression { params.RUN_BACKUP == true || params.RUN_INGESTION == true }
+                expression {
+                    shouldRunPipeline() && (params.RUN_BACKUP == true || params.RUN_INGESTION == true)
+                }
             }
             environment {
                 QDRANT_URL        = credentials('qdrant-url')
@@ -269,7 +299,9 @@ pipeline {
         // ------------------------------------------------------------------ //
         stage('Archive Artifacts') {
             when {
-                expression { params.RUN_INGESTION == true || params.RUN_BACKUP == true }
+                expression {
+                    shouldRunPipeline() && (params.RUN_INGESTION == true || params.RUN_BACKUP == true)
+                }
             }
             steps {
                 archiveArtifacts(
@@ -282,9 +314,66 @@ pipeline {
 
     post {
         always {
-            sh 'make clean || true'
-            sh 'make ci-down || true'
-            cleanWs()
+            script {
+                if (shouldRunPipeline()) {
+                    sh 'make clean || true'
+                    sh 'make ci-down || true'
+                } else {
+                    echo 'Skipping Docker cleanup because no RAG CI stages ran.'
+                }
+                cleanWs()
+            }
+        }
+    }
+}
+
+// -------------------------------------------------------------------------- //
+def shouldRunPipeline() {
+    if (pipelineEligibility != null) {
+        return pipelineEligibility
+    }
+
+    if (env.CHANGE_ID) {
+        pipelineEligibility = !isDraftPullRequest()
+        return pipelineEligibility
+    }
+
+    pipelineEligibility = env.BRANCH_NAME == 'main'
+    return pipelineEligibility
+}
+
+// -------------------------------------------------------------------------- //
+def isDraftPullRequest() {
+    withCredentials([
+        usernamePassword(
+            credentialsId: 'github-pat',
+            usernameVariable: 'GITHUB_USER',
+            passwordVariable: 'GITHUB_TOKEN'
+        )
+    ]) {
+        withEnv(["PR_NUMBER=${env.CHANGE_ID}"]) {
+            def draft = sh(
+                script: '''
+                    set +x
+                    python3 - <<'PY'
+import json
+import os
+import urllib.request
+
+request = urllib.request.Request(
+    f"https://api.github.com/repos/aharbii/movie-finder-rag/pulls/{os.environ['PR_NUMBER']}",
+    headers={
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+    },
+)
+with urllib.request.urlopen(request, timeout=20) as response:
+    print(str(bool(json.load(response).get("draft"))).lower())
+PY
+                ''',
+                returnStdout: true,
+            ).trim()
+            return draft == 'true'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,8 +38,6 @@
 // Required Jenkins plugins: Docker Pipeline, JUnit, Coverage, Credentials Binding
 // =============================================================================
 
-def pipelineEligibility = null
-
 pipeline {
     agent any
 
@@ -329,17 +327,22 @@ pipeline {
 
 // -------------------------------------------------------------------------- //
 def shouldRunPipeline() {
-    if (pipelineEligibility != null) {
-        return pipelineEligibility
+    if (env.RAG_CI_ELIGIBLE?.trim()) {
+        return env.RAG_CI_ELIGIBLE == 'true'
     }
 
+    def eligible = resolvePipelineEligibility()
+    env.RAG_CI_ELIGIBLE = eligible.toString()
+    return eligible
+}
+
+// -------------------------------------------------------------------------- //
+def resolvePipelineEligibility() {
     if (env.CHANGE_ID) {
-        pipelineEligibility = !isDraftPullRequest()
-        return pipelineEligibility
+        return !isDraftPullRequest()
     }
 
-    pipelineEligibility = env.BRANCH_NAME == 'main'
-    return pipelineEligibility
+    return env.BRANCH_NAME == 'main'
 }
 
 // -------------------------------------------------------------------------- //

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,20 +2,34 @@
 // movie-finder-rag — Jenkins declarative pipeline
 //
 // Pipeline modes (Jenkins Multibranch Pipeline):
-//   PR build       — every pull request: Lint + Typecheck + Test (no image build)
-//   Main build     — push to main: Lint + Typecheck + Test (no image build)
+//   PR build       — every pull request: Lint + Typecheck + Test
+//   Main build     — push to main: Lint + Typecheck + Test
 //   Manual ops     — "Build with Parameters" with RUN_INGESTION/RUN_BACKUP=true:
-//                    Lint + Typecheck + Test + optional ingest/backup against live vector store
+//                    Lint + Typecheck + Test + optional ingest + validate + backup
 //
 // NOTE: This image is NOT pushed to ACR. The rag pipeline is an offline
 // one-shot ingestion tool run manually. Only backend and frontend images are
 // published to ACR.
 //
+// Docker-only contract:
+// - All commands run through the repo Makefile and Docker Compose.
+// - Do not assume host Python, host Ollama, or localhost-only services.
+// - ChromaDB may be local to the mounted workspace path; remote backends remain external.
+//
+// ADR 0008 runtime contract:
+// - Embedding provider/model are selected via EMBEDDING_PROVIDER / EMBEDDING_MODEL.
+// - Final target name is derived from COLLECTION_PREFIX + sanitized model + dimension.
+// - Backups are normalized into a portable ChromaDB artifact regardless of source backend.
+//
 // Required Jenkins Credential IDs (see docs/devops-setup.md):
-//   qdrant-url           (Secret Text)   — Manual ingest / backup only
-//   qdrant-api-key-rw    (Secret Text)   — Manual ingest / backup only
-//   openai-api-key       (Secret Text)   — Manual ingest only
-//   kaggle-api-token     (Secret Text)   — Manual ingest only
+//   qdrant-url           (Secret Text)   — qdrant ingest / validate / backup
+//   qdrant-api-key-rw    (Secret Text)   — qdrant ingest / validate / backup
+//   openai-api-key       (Secret Text)   — openai embeddings
+//   google-api-key       (Secret Text)   — google embeddings
+//   ollama-api-key       (Secret Text)   — ollama cloud, when used
+//   pinecone-api-key     (Secret Text)   — pinecone backend, when used
+//   pgvector-dsn         (Secret Text)   — pgvector backend, when used
+//   kaggle-api-token     (Secret Text)   — dataset download
 //
 // Required Jenkins plugins: Docker Pipeline, JUnit, Coverage, Credentials Binding
 // =============================================================================
@@ -33,38 +47,119 @@ pipeline {
         booleanParam(
             name: 'RUN_INGESTION',
             defaultValue: false,
-            description: 'Run the offline ingestion pipeline against Qdrant Cloud (requires live credentials).'
+            description: 'Run the offline ingestion pipeline against the configured vector store.'
         )
         booleanParam(
             name: 'RUN_BACKUP',
             defaultValue: false,
-            description: 'Run the backup utility against a live vector store and archive the local artifact.'
+            description: 'Run the backup utility and archive the generated artifact.'
+        )
+        choice(
+            name: 'EMBEDDING_PROVIDER',
+            choices: ['openai', 'ollama', 'huggingface', 'sentence-transformers', 'google'],
+            description: 'ADR 0008 embedding provider selection.'
         )
         string(
-            name: 'COLLECTION_NAME',
+            name: 'EMBEDDING_MODEL',
+            defaultValue: 'text-embedding-3-large',
+            description: 'Embedding model identifier for the selected provider.'
+        )
+        string(
+            name: 'EMBEDDING_DIMENSIONS',
+            defaultValue: '',
+            description: 'Optional output dimension override for providers that support it.'
+        )
+        password(
+            name: 'EMBEDDING_API_KEY',
+            defaultValue: '',
+            description: 'Optional API key override for OpenAI, Google, or Ollama cloud.'
+        )
+        string(
+            name: 'COLLECTION_PREFIX',
             defaultValue: 'movies',
-            description: 'Collection name to ingest and/or back up. Defaults to "movies".'
+            description: 'Qdrant collection prefix. Final target is resolved dynamically per ADR 0008.'
         )
         choice(
             name: 'VECTOR_STORE',
-            choices: ['qdrant'],
-            description: 'Vector store type for the backup utility. Extend as new adapters are added.'
+            choices: ['qdrant', 'chromadb', 'pinecone', 'pgvector'],
+            description: 'Vector store backend for ingestion and validation.'
+        )
+        string(
+            name: 'VECTOR_STORE_URL',
+            defaultValue: '',
+            description: 'Optional qdrant URL override for qdrant backups.'
+        )
+        password(
+            name: 'VECTOR_STORE_API_KEY',
+            defaultValue: '',
+            description: 'Optional qdrant or pinecone API key override.'
+        )
+        string(
+            name: 'OLLAMA_URL',
+            defaultValue: 'http://ollama:11434',
+            description: 'Docker-reachable Ollama base URL when EMBEDDING_PROVIDER=ollama.'
+        )
+        string(
+            name: 'CHROMADB_PERSIST_PATH',
+            defaultValue: 'outputs/chromadb/local',
+            description: 'Persistent path for chromadb ingestion and backup.'
+        )
+        string(
+            name: 'PINECONE_INDEX_NAME',
+            defaultValue: 'movie-finder-rag',
+            description: 'Pinecone index name when VECTOR_STORE=pinecone.'
+        )
+        string(
+            name: 'PINECONE_INDEX_HOST',
+            defaultValue: '',
+            description: 'Optional Pinecone host override.'
+        )
+        string(
+            name: 'PINECONE_CLOUD',
+            defaultValue: 'aws',
+            description: 'Pinecone serverless cloud when an index must be created.'
+        )
+        string(
+            name: 'PINECONE_REGION',
+            defaultValue: 'us-east-1',
+            description: 'Pinecone serverless region when an index must be created.'
+        )
+        password(
+            name: 'PGVECTOR_DSN_OVERRIDE',
+            defaultValue: '',
+            description: 'Optional pgvector PostgreSQL DSN override.'
+        )
+        string(
+            name: 'PGVECTOR_SCHEMA',
+            defaultValue: 'public',
+            description: 'Schema token used when VECTOR_STORE=pgvector.'
+        )
+        string(
+            name: 'WITH_PROVIDERS',
+            defaultValue: '',
+            description: 'Docker build extra groups, for example `local`.'
+        )
+        string(
+            name: 'VALIDATION_QUERY',
+            defaultValue: 'A time-travel movie with a scientist and a DeLorean',
+            description: 'Smoke-test query for the post-ingest validation stage.'
         )
     }
 
     environment {
         SERVICE_NAME = 'movie-finder-rag'
         DOCKER_BUILDKIT = '1'
-        // Isolate compose project per build so parallel CI runs don't collide.
         COMPOSE_PROJECT_NAME = "movie-finder-rag-ci-${env.BUILD_NUMBER}"
     }
 
     stages {
-
         // ------------------------------------------------------------------ //
         stage('Initialize') {
             steps {
-                sh 'make init'
+                script {
+                    env.WITH_PROVIDERS = params.WITH_PROVIDERS ?: ''
+                    sh 'make init'
+                }
             }
         }
 
@@ -89,9 +184,7 @@ pipeline {
                 always {
                     junit allowEmptyResults: true, testResults: 'reports/junit.xml'
                     recordCoverage(
-                        tools: [
-                            [parser: 'COBERTURA', pattern: 'reports/coverage.xml']
-                        ],
+                        tools: [[parser: 'COBERTURA', pattern: 'reports/coverage.xml']],
                         id: 'coverage',
                         name: 'RAG Coverage',
                         sourceCodeRetention: 'EVERY_BUILD',
@@ -115,20 +208,38 @@ pipeline {
                 QDRANT_URL        = credentials('qdrant-url')
                 QDRANT_API_KEY_RW = credentials('qdrant-api-key-rw')
                 OPENAI_API_KEY    = credentials('openai-api-key')
+                GOOGLE_API_KEY    = credentials('google-api-key')
+                OLLAMA_API_KEY    = credentials('ollama-api-key')
+                PINECONE_API_KEY  = credentials('pinecone-api-key')
+                PGVECTOR_DSN      = credentials('pgvector-dsn')
                 KAGGLE_API_TOKEN  = credentials('kaggle-api-token')
             }
             steps {
                 script {
-                    // env blocks only allow literals or credentials() calls.
-                    // Use script {} to evaluate the default-value expression.
-                    env.QDRANT_COLLECTION_NAME = params.COLLECTION_NAME ?: 'movies'
-                    echo "Target collection: ${env.QDRANT_COLLECTION_NAME}"
+                    configureRuntimeEnv()
                     sh 'make ingest'
                 }
             }
-            post {
-                always {
-                    archiveArtifacts artifacts: 'ingestion-outputs.env', allowEmptyArchive: true
+        }
+
+        // ------------------------------------------------------------------ //
+        stage('Post-Ingest Validate') {
+            when {
+                expression { params.RUN_INGESTION == true }
+            }
+            environment {
+                QDRANT_URL        = credentials('qdrant-url')
+                QDRANT_API_KEY_RW = credentials('qdrant-api-key-rw')
+                OPENAI_API_KEY    = credentials('openai-api-key')
+                GOOGLE_API_KEY    = credentials('google-api-key')
+                OLLAMA_API_KEY    = credentials('ollama-api-key')
+                PINECONE_API_KEY  = credentials('pinecone-api-key')
+                PGVECTOR_DSN      = credentials('pgvector-dsn')
+            }
+            steps {
+                script {
+                    configureRuntimeEnv()
+                    sh 'make validate'
                 }
             }
         }
@@ -141,26 +252,32 @@ pipeline {
             environment {
                 QDRANT_URL        = credentials('qdrant-url')
                 QDRANT_API_KEY_RW = credentials('qdrant-api-key-rw')
+                OPENAI_API_KEY    = credentials('openai-api-key')
+                GOOGLE_API_KEY    = credentials('google-api-key')
+                OLLAMA_API_KEY    = credentials('ollama-api-key')
+                PINECONE_API_KEY  = credentials('pinecone-api-key')
+                PGVECTOR_DSN      = credentials('pgvector-dsn')
             }
             steps {
                 script {
-                    env.VECTOR_STORE = params.VECTOR_STORE ?: 'qdrant'
-                    env.BACKUP_COLLECTION_NAME = params.COLLECTION_NAME ?: 'movies'
-                    env.BACKUP_OUTPUT_ROOT = 'outputs/backups/chromadb'
-                    env.VECTOR_STORE_URL = env.QDRANT_URL
-                    env.VECTOR_STORE_API_KEY = env.QDRANT_API_KEY_RW
-                    echo "Backup source: ${env.VECTOR_STORE}"
-                    echo "Backup collection: ${env.BACKUP_COLLECTION_NAME}"
+                    configureRuntimeEnv()
                     sh 'make backup'
-                }
-            }
-            post {
-                always {
-                    archiveArtifacts artifacts: 'outputs/backups/**', allowEmptyArchive: true
                 }
             }
         }
 
+        // ------------------------------------------------------------------ //
+        stage('Archive Artifacts') {
+            when {
+                expression { params.RUN_INGESTION == true || params.RUN_BACKUP == true }
+            }
+            steps {
+                archiveArtifacts(
+                    artifacts: 'ingestion-outputs.env,outputs/reports/**,outputs/backups/**',
+                    allowEmptyArchive: true
+                )
+            }
+        }
     }
 
     post {
@@ -169,18 +286,50 @@ pipeline {
             sh 'make ci-down || true'
             cleanWs()
         }
-        failure {
-            echo "Pipeline failed on ${env.BRANCH_NAME ?: 'manual trigger'} — check logs above."
+    }
+}
+
+// -------------------------------------------------------------------------- //
+def configureRuntimeEnv() {
+    env.WITH_PROVIDERS = params.WITH_PROVIDERS ?: ''
+    env.EMBEDDING_PROVIDER = params.EMBEDDING_PROVIDER ?: 'openai'
+    env.EMBEDDING_MODEL = params.EMBEDDING_MODEL ?: 'text-embedding-3-large'
+    env.EMBEDDING_DIMENSIONS = params.EMBEDDING_DIMENSIONS ?: ''
+    env.OLLAMA_URL = params.OLLAMA_URL ?: env.OLLAMA_URL
+    env.QDRANT_COLLECTION_PREFIX = params.COLLECTION_PREFIX ?: 'movies'
+    env.VECTOR_STORE = params.VECTOR_STORE ?: 'qdrant'
+    env.VALIDATION_QUERY = params.VALIDATION_QUERY ?: 'A time-travel movie with a scientist and a DeLorean'
+    env.CHROMADB_PERSIST_PATH = params.CHROMADB_PERSIST_PATH ?: env.CHROMADB_PERSIST_PATH ?: 'outputs/chromadb/local'
+    env.PINECONE_INDEX_NAME = params.PINECONE_INDEX_NAME ?: env.PINECONE_INDEX_NAME ?: 'movie-finder-rag'
+    env.PINECONE_INDEX_HOST = params.PINECONE_INDEX_HOST ?: env.PINECONE_INDEX_HOST
+    env.PINECONE_CLOUD = params.PINECONE_CLOUD ?: env.PINECONE_CLOUD ?: 'aws'
+    env.PINECONE_REGION = params.PINECONE_REGION ?: env.PINECONE_REGION ?: 'us-east-1'
+    env.PGVECTOR_SCHEMA = params.PGVECTOR_SCHEMA ?: env.PGVECTOR_SCHEMA ?: 'public'
+
+    if (params.EMBEDDING_API_KEY?.trim()) {
+        if (env.EMBEDDING_PROVIDER == 'openai') {
+            env.OPENAI_API_KEY = params.EMBEDDING_API_KEY
+        } else if (env.EMBEDDING_PROVIDER == 'google') {
+            env.GOOGLE_API_KEY = params.EMBEDDING_API_KEY
+        } else if (env.EMBEDDING_PROVIDER == 'ollama') {
+            env.OLLAMA_API_KEY = params.EMBEDDING_API_KEY
         }
-        success {
-            script {
-                if (params.RUN_INGESTION) {
-                    echo "Ingestion into '${env.QDRANT_COLLECTION_NAME}' completed successfully."
-                }
-                if (params.RUN_BACKUP || params.RUN_INGESTION) {
-                    echo "Backup artifact archived from outputs/backups/."
-                }
-            }
-        }
+    }
+
+    if (env.VECTOR_STORE == 'qdrant') {
+        env.VECTOR_STORE_URL = params.VECTOR_STORE_URL ?: env.QDRANT_URL
+        env.VECTOR_STORE_API_KEY = params.VECTOR_STORE_API_KEY?.trim() ? params.VECTOR_STORE_API_KEY : env.QDRANT_API_KEY_RW
+    } else if (env.VECTOR_STORE == 'pinecone') {
+        env.PINECONE_INDEX_HOST = params.PINECONE_INDEX_HOST ?: params.VECTOR_STORE_URL ?: env.PINECONE_INDEX_HOST
+        env.PINECONE_API_KEY = params.VECTOR_STORE_API_KEY?.trim() ? params.VECTOR_STORE_API_KEY : env.PINECONE_API_KEY
+        env.VECTOR_STORE_URL = env.PINECONE_INDEX_HOST
+        env.VECTOR_STORE_API_KEY = env.PINECONE_API_KEY
+    } else if (env.VECTOR_STORE == 'pgvector') {
+        env.PGVECTOR_DSN = params.PGVECTOR_DSN_OVERRIDE?.trim() ? params.PGVECTOR_DSN_OVERRIDE : env.PGVECTOR_DSN
+        env.VECTOR_STORE_URL = env.PGVECTOR_DSN
+        env.VECTOR_STORE_API_KEY = ''
+    } else if (env.VECTOR_STORE == 'chromadb') {
+        env.VECTOR_STORE_URL = ''
+        env.VECTOR_STORE_API_KEY = ''
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 .PHONY: help init build setup clean clean-docker \
 	editor-up editor-down ci-down shell logs up down  run run-dev \
 	lint format fix typecheck test test-coverage pre-commit detect-secrets check \
-	backup retrieve validate
+	backup retrieve validate migrate-legacy-qdrant-collection
 
 
 .DEFAULT_GOAL := help
@@ -40,6 +40,7 @@ COVERAGE_XML ?= reports/coverage.xml
 COVERAGE_HTML ?= reports/htmlcov
 JUNIT_XML ?= reports/junit.xml
 BACKUP_ARGS ?=
+MIGRATE_ARGS ?=
 
 # ---------------------------------------------------------------------------
 # exec when running, run --rm otherwise — avoids container startup overhead
@@ -99,6 +100,7 @@ help:
 	@echo "    backup         Runs the Docker-backed backup utility and writes artifacts under outputs/"
 	@echo "    retrieve       Runs an interactive app to validate the retrieval logic"
 	@echo "    validate       Runs the post-ingest validation script"
+	@echo "    migrate-legacy-qdrant-collection  Backs up and migrates a legacy Qdrant collection into the ADR-style name"
 	@echo ""
 
 init:
@@ -191,3 +193,6 @@ retrieve:
 
 validate:
 	$(call exec_or_run,python scripts/validate_ingestion.py)
+
+migrate-legacy-qdrant-collection:
+	$(call exec_or_run,python scripts/migrate_legacy_qdrant_collection.py $(MIGRATE_ARGS))

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #
 # All developer commands execute through Docker Compose so linting, testing,
 # formatting, and pre-commit do not depend on a host-managed Python environment.
-# Qdrant is always external — no local Qdrant container is provided.
+# Remote vector stores stay external; local ChromaDB uses the mounted workspace path.
 #
 # Typical first-time flow:
 #   make init        # build images + create .env + install git hook
@@ -21,7 +21,7 @@
 .PHONY: help init build setup clean clean-docker \
 	editor-up editor-down ci-down shell logs up down  run run-dev \
 	lint format fix typecheck test test-coverage pre-commit detect-secrets check \
-	backup retrieve
+	backup retrieve validate
 
 
 .DEFAULT_GOAL := help
@@ -93,11 +93,12 @@ help:
 	@echo "    setup          Alias for init"
 	@echo ""
 	@echo "  Pipeline"
-	@echo "    ingest         Run the one-shot ingestion pipeline against external Qdrant"
+	@echo "    ingest         Run the one-shot ingestion pipeline against the configured vector store"
 	@echo ""
 	@echo "  Apps"
 	@echo "    backup         Runs the Docker-backed backup utility and writes artifacts under outputs/"
 	@echo "    retrieve       Runs an interactive app to validate the retrieval logic"
+	@echo "    validate       Runs the post-ingest validation script"
 	@echo ""
 
 init:
@@ -187,3 +188,6 @@ backup:
 
 retrieve:
 	$(call exec_or_run,python scripts/retrieve.py)
+
+validate:
+	$(call exec_or_run,python scripts/validate_ingestion.py)

--- a/README.md
+++ b/README.md
@@ -1,22 +1,30 @@
 # Movie Finder RAG
 
-Offline ingestion pipeline for Movie Finder. Downloads the [Wikipedia Movie Plots](https://www.kaggle.com/datasets/jrobischon/wikipedia-movie-plots) Kaggle dataset, generates OpenAI embeddings, and upserts them into a Qdrant Cloud collection.
+Offline ingestion pipeline for Movie Finder. It downloads the
+[Wikipedia Movie Plots](https://www.kaggle.com/datasets/jrobischon/wikipedia-movie-plots)
+dataset, generates embeddings through the ADR 0008 provider factory, and writes vectors into the
+configured store.
 
-Contributor workflow in this repo is **strictly Docker-only**: all quality gates (lint,
-test, typecheck, test-coverage, pre-commit) execute through the provided `Makefile`.
-Host-managed Python environments are not supported for development.
+Contributor workflow in this repo is Docker-only. Lint, tests, type checks, ingestion, validation,
+and backup all run through the committed `Makefile`. Host-managed Python environments are not part
+of the supported developer workflow.
 
 ---
 
 ## Overview
 
 ```text
-Kaggle CSV -> CSV Loader -> Embedding Provider -> Qdrant Cloud
-               (pandas)      (OpenAI/Gemini)      (write-capable key)
+Kaggle CSV -> CSV Loader -> Embedding Provider Factory -> Vector Store Factory
+               (pandas)      (OpenAI/Ollama/HuggingFace/Google) (Qdrant/Chroma/Pinecone/PGVector)
 ```
 
-The pipeline is re-runnable whenever the dataset changes or a fresh collection needs to be built
-for the `chain` package.
+ADR 0008 contract:
+
+- Embedding runtime is environment-driven via `EMBEDDING_PROVIDER` and `EMBEDDING_MODEL`.
+- Heavy local SDKs are installed only when `WITH_PROVIDERS=local`.
+- Final target name is resolved as
+  `{QDRANT_COLLECTION_PREFIX}_{sanitized_model}_{dimension}`.
+- Query-time and ingestion-time embeddings must still be coordinated with `chain/`.
 
 ---
 
@@ -26,37 +34,45 @@ for the `chain` package.
 
 - Docker 24+ with the Compose plugin
 - GNU Make
-- Qdrant Cloud write-capable credentials
-- OpenAI API key
-- Kaggle API token (`KGAT_` prefixed token)
+- Kaggle API token (`KGAT_...`)
+- Provider credentials or a local runtime, depending on `EMBEDDING_PROVIDER`
+- Vector store credentials for the selected `VECTOR_STORE`
 
 ### Setup
 
 ```bash
-make init       # build dev + runtime images, create .env from template, install git hook
-make editor-up  # start the attached-container workspace
+make init
+make editor-up
 ```
 
-After `make editor-up`, open `.env` and fill in the required API keys.
-`make editor-up` starts the long-lived workspace container used for VS Code attach/debug flows.
-The actual ingestion pipeline is still a one-shot command.
+If you want local HuggingFace / sentence-transformers support, set `WITH_PROVIDERS=local` before
+building:
+
+```bash
+WITH_PROVIDERS=local make init
+```
 
 ### Common Commands
 
 ```bash
-make init           # build dev + runtime images, create .env from template, install git hook
-make editor-up      # start the attached-container workspace
-make editor-down    # stop the local workspace container
-make shell          # open zsh shell in the workspace container
+make init
+make editor-up
+make editor-down
+make shell
 
-make lint           # ruff check (report only)
-make fix            # ruff check --fix + ruff format (auto-apply)
-make format         # ruff format
-make typecheck      # mypy (strict)
-make test           # pytest tests/
-make test-coverage  # pytest + coverage.xml + htmlcov + JUnit report
-make pre-commit     # full hook suite (also enforced on git commit)
-make check          # lint + typecheck + test-coverage (CI gate)
+make lint
+make fix
+make format
+make typecheck
+make test
+make test-coverage
+make pre-commit
+make check
+
+make ingest
+make validate
+make backup
+make retrieve
 ```
 
 ### Ingestion
@@ -65,8 +81,19 @@ make check          # lint + typecheck + test-coverage (CI gate)
 make ingest
 ```
 
-`make ingest` runs the runtime image against external Qdrant Cloud using the variables in `.env`.
-No local Qdrant compose workflow exists in this repo.
+`make ingest` runs the runtime image against the configured vector store using variables from
+`.env`. For remote backends, credentials stay external to the repo. For `chromadb`, persistence is
+through the mounted workspace path inside Docker.
+
+### Validation
+
+```bash
+make validate
+```
+
+`make validate` performs a post-ingestion smoke check using the configured provider and vector
+store. It is intended to confirm that the freshly written target can be queried end-to-end, not to
+replace a broader retrieval evaluation suite.
 
 ### Backup
 
@@ -74,29 +101,83 @@ No local Qdrant compose workflow exists in this repo.
 make backup
 ```
 
-`make backup` runs the backup utility inside Docker using the committed compose stack, so it does
-not depend on host Python packages. With the current repo configuration, `.env` values like
-`QDRANT_URL`, `QDRANT_API_KEY_RW`, and `QDRANT_COLLECTION_NAME` are enough for the current
-Qdrant adapter.
+`make backup` runs inside Docker and exports the configured source backend into a portable ChromaDB
+artifact. This lets CI archive one stable backup format even when the source backend is `qdrant`,
+`chromadb`, `pinecone`, or `pgvector`.
 
-For CI and future vector store adapters, the script also accepts generic CLI/env inputs:
+---
 
-```bash
-make backup BACKUP_ARGS="--vector-store qdrant --collection-name movies"
-```
+## Provider Configuration
 
-Generic env fallbacks used by the script:
+The canonical embedding settings are:
 
-| Variable               | Description                                           |
-| ---------------------- | ----------------------------------------------------- |
-| `VECTOR_STORE`         | Backup source type, currently `qdrant`                |
-| `VECTOR_STORE_URL`     | Live vector store endpoint                            |
-| `VECTOR_STORE_API_KEY` | Live vector store API key                             |
-| `BACKUP_COLLECTION_NAME` | Collection name to back up                          |
-| `BACKUP_OUTPUT_ROOT`   | Root directory for generated backup artifacts         |
-| `BACKUP_BATCH_SIZE`    | Batch size for remote pagination                      |
+| Variable | Required | Description |
+| --- | --- | --- |
+| `EMBEDDING_PROVIDER` | Yes | `openai`, `ollama`, `huggingface`, `sentence-transformers`, or `google` |
+| `EMBEDDING_MODEL` | Yes | Model identifier for the selected provider |
+| `EMBEDDING_DIMENSIONS` | No | Optional dimension override for providers that support it |
+| `WITH_PROVIDERS` | No | Docker build extra, usually `local` for sentence-transformers + torch |
 
-Artifacts are written to `outputs/backups/chromadb/<vector-store>/<collection>/`.
+Provider-specific credentials:
+
+| Variable | Required When | Description |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | `EMBEDDING_PROVIDER=openai` | OpenAI embeddings API key |
+| `GOOGLE_API_KEY` | `EMBEDDING_PROVIDER=google` | Google embeddings API key |
+| `OLLAMA_URL` | `EMBEDDING_PROVIDER=ollama` | Ollama base URL, local or cloud |
+| `OLLAMA_API_KEY` | Optional | Required for Ollama cloud |
+| `SENTENCE_TRANSFORMERS_CACHE_DIR` | Optional | Cache directory for local HuggingFace models |
+
+---
+
+## Vector Store Configuration
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `VECTOR_STORE` | Yes | `qdrant`, `chromadb`, `pinecone`, or `pgvector` |
+| `QDRANT_COLLECTION_PREFIX` | Yes | Prefix used for ADR 0008 target naming |
+| `VECTOR_STORE_URL` | No | Generic qdrant backup endpoint override |
+| `VECTOR_STORE_API_KEY` | No | Generic qdrant or pinecone backup API key override |
+
+Backend-specific settings:
+
+| Variable | Required When | Description |
+| --- | --- | --- |
+| `QDRANT_URL` | `VECTOR_STORE=qdrant` | Qdrant cluster URL |
+| `QDRANT_API_KEY_RW` | `VECTOR_STORE=qdrant` | Write-capable Qdrant API key |
+| `CHROMADB_PERSIST_PATH` | `VECTOR_STORE=chromadb` | Local persistence path inside Docker, default `outputs/chromadb/local` |
+| `PINECONE_API_KEY` | `VECTOR_STORE=pinecone` | Pinecone API key |
+| `PINECONE_INDEX_NAME` | `VECTOR_STORE=pinecone` | Pinecone index name |
+| `PINECONE_INDEX_HOST` | Optional | Existing Pinecone host override |
+| `PINECONE_CLOUD` / `PINECONE_REGION` | Optional | Serverless creation settings |
+| `PGVECTOR_DSN` | `VECTOR_STORE=pgvector` | PostgreSQL DSN with pgvector enabled |
+| `PGVECTOR_SCHEMA` | Optional | Schema token used for pgvector target names |
+
+---
+
+## Ingestion Outputs
+
+`make ingest` now emits:
+
+- `ingestion-outputs.env`
+- `outputs/reports/cost-report.json`
+
+`make validate` emits:
+
+- `outputs/reports/validation-report.json`
+
+`make backup` emits:
+
+- `outputs/backups/**`
+- `outputs/backups/**/backup-manifest.json`
+
+Backups always emit a portable ChromaDB artifact, regardless of whether the source vector store is
+`qdrant`, `chromadb`, `pinecone`, or `pgvector`. The manifest records the source backend together
+with the embedding provider, model, and final dimension so the artifact can be traced back to the
+ingestion run that created it.
+
+These artifacts are consumed by the Jenkins job for archiving and for backing up the dynamically
+resolved target name after ingestion.
 
 ---
 
@@ -104,7 +185,7 @@ Artifacts are written to `outputs/backups/chromadb/<vector-store>/<collection>/`
 
 The committed `.vscode/` config assumes this workflow:
 
-1. Run `make editor-up` from the host workspace.
+1. Run `make editor-up` from this repo.
 2. Use `Dev Containers: Attach to Running Container...`.
 3. Attach to the `rag` service container started from this repo.
 4. Use the committed tasks for `make ...` targets.
@@ -114,38 +195,34 @@ The interpreter path inside the container is `/opt/venv/bin/python`.
 
 ---
 
-## Environment
+## CI/CD
 
-Canonical variables for this repo (DNA aligned with `infrastructure#9`):
+The repo-local `Jenkinsfile` and `.github/workflows/ci.yml` both accept the ADR 0008 provider
+settings directly:
 
-| Variable                 | Required | Description                                |
-| ------------------------ | -------- | ------------------------------------------ |
-| `QDRANT_URL`             | Yes      | Qdrant Cloud cluster URL                   |
-| `QDRANT_API_KEY_RW`      | Yes      | Write-capable Qdrant API key               |
-| `QDRANT_COLLECTION_NAME` | Yes      | Shared collection name consumed by `chain` |
-| `OPENAI_API_KEY`         | Yes      | OpenAI API key for embeddings              |
-| `KAGGLE_API_TOKEN`       | Yes      | Standalone token prefixed with `KGAT_`     |
+- `EMBEDDING_PROVIDER`
+- `EMBEDDING_MODEL`
+- `EMBEDDING_DIMENSIONS`
+- `EMBEDDING_API_KEY`
+- `VECTOR_STORE`
+- `OLLAMA_URL`
+- `CHROMADB_PERSIST_PATH`
+- `PINECONE_INDEX_NAME`
+- `PINECONE_INDEX_HOST`
+- `PINECONE_CLOUD`
+- `PINECONE_REGION`
+- `PGVECTOR_SCHEMA`
+- `WITH_PROVIDERS`
 
----
+Post-ingest CI flow:
 
-## CI/CD Pipeline
+1. `make ingest`
+2. `make validate`
+3. `make backup`
+4. Archive `ingestion-outputs.env`, `outputs/reports/**`, and `outputs/backups/**`
 
-See `Jenkinsfile` for the full pipeline. The current stages line up with the repo-local
-developer contract:
-
-| Stage            | Command / trigger                   | Notes                            |
-| ---------------- | ----------------------------------- | -------------------------------- |
-| Lint + Typecheck | `make lint` + `make typecheck`      | PRs, `main`, tags                |
-| Test             | `make test-coverage`                | PRs, `main`, tags                |
-| Ingest           | Manual `RUN_INGESTION=true`         | Parameterized Jenkins / Actions run |
-| Backup           | Manual `RUN_BACKUP=true` or post-ingest | Archives `outputs/backups/**` artifact |
-
-Live CI operations remain manual-only. Secrets should be provided by the CI system:
-
-- Jenkins: `credentials('qdrant-url')`, `credentials('qdrant-api-key-rw')`,
-  `credentials('openai-api-key')`, `credentials('kaggle-api-token')`
-- GitHub Actions: `secrets.QDRANT_URL`, `secrets.QDRANT_API_KEY_RW`,
-  `secrets.OPENAI_API_KEY`, `secrets.KAGGLE_API_TOKEN`
+Live CI operations remain manual-only for ingestion-style runs. Credentials should be provided by
+the CI system rather than committed env files.
 
 ---
 
@@ -154,8 +231,9 @@ Live CI operations remain manual-only. Secrets should be provided by the CI syst
 After a successful ingestion run, share these values with the chain team:
 
 ```text
-QDRANT_URL=<qdrant-cloud-endpoint>
-QDRANT_COLLECTION_NAME=<collection-name>
-EMBEDDING_MODEL=text-embedding-3-large
-EMBEDDING_DIMENSION=3072
+VECTOR_STORE=<backend>
+VECTOR_STORE_TARGET_NAME=<resolved-target-name>
+EMBEDDING_PROVIDER=<provider>
+EMBEDDING_MODEL=<model>
+EMBEDDING_DIMENSION=<final-dimension>
 ```

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Backend-specific settings:
 
 - `ingestion-outputs.env`
 - `outputs/reports/cost-report.json`
+- `outputs/reports/skipped-movies.json`
 
 `make validate` emits:
 

--- a/ai-context/README.md
+++ b/ai-context/README.md
@@ -4,7 +4,7 @@ Shared reference for AI agents working in this repo standalone.
 
 ## Available slash commands (Claude Code)
 
-Open `backend/rag_ingestion/` as your workspace, then type `/`:
+Open `rag/` as your workspace, then type `/`:
 
 | Command                     | Usage                             |
 | --------------------------- | --------------------------------- |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,3 @@
-# =============================================================================
-# movie-finder-rag — Docker-only local development stack
-#
-# Services:
-#   rag        Attached-container workspace for lint/test/debug/editor flows
-#   ingestion  One-shot runtime image for the manual ingestion entrypoint
-#
-# Qdrant is external-only. No local Qdrant container is supported here.
-# =============================================================================
-
 name: movie-finder-rag-local
 
 services:
@@ -16,24 +6,40 @@ services:
       context: .
       dockerfile: Dockerfile
       target: dev
+      args:
+        WITH_PROVIDERS: ${WITH_PROVIDERS:-}
     image: movie-finder-rag:dev
     working_dir: /workspace
-    command:
-      - "sleep"
-      - "infinity"
+    command: ["sleep", "infinity"]
     environment:
       GIT_DIR: /workspace/.gitdir
       GIT_WORK_TREE: /workspace
-      VECTOR_STORE: ${VECTOR_STORE:-}
+      VECTOR_STORE: ${VECTOR_STORE:-qdrant}
       VECTOR_STORE_URL: ${VECTOR_STORE_URL:-}
       VECTOR_STORE_API_KEY: ${VECTOR_STORE_API_KEY:-}
       BACKUP_COLLECTION_NAME: ${BACKUP_COLLECTION_NAME:-}
       BACKUP_OUTPUT_ROOT: ${BACKUP_OUTPUT_ROOT:-}
       BACKUP_BATCH_SIZE: ${BACKUP_BATCH_SIZE:-}
+      CHROMADB_PERSIST_PATH: ${CHROMADB_PERSIST_PATH:-}
+      PINECONE_API_KEY: ${PINECONE_API_KEY:-}
+      PINECONE_INDEX_NAME: ${PINECONE_INDEX_NAME:-}
+      PINECONE_INDEX_HOST: ${PINECONE_INDEX_HOST:-}
+      PINECONE_CLOUD: ${PINECONE_CLOUD:-}
+      PINECONE_REGION: ${PINECONE_REGION:-}
+      PGVECTOR_DSN: ${PGVECTOR_DSN:-}
+      PGVECTOR_SCHEMA: ${PGVECTOR_SCHEMA:-}
       QDRANT_URL: ${QDRANT_URL:-}
       QDRANT_API_KEY_RW: ${QDRANT_API_KEY_RW:-}
-      QDRANT_COLLECTION_NAME: ${QDRANT_COLLECTION_NAME:-movies}
+      QDRANT_COLLECTION_PREFIX: ${QDRANT_COLLECTION_PREFIX:-movies}
+      EMBEDDING_PROVIDER: ${EMBEDDING_PROVIDER:-openai}
+      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-text-embedding-3-large}
+      EMBEDDING_DIMENSIONS: ${EMBEDDING_DIMENSIONS:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
+      OLLAMA_URL: ${OLLAMA_URL:-}
+      OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
+      SENTENCE_TRANSFORMERS_CACHE_DIR: ${SENTENCE_TRANSFORMERS_CACHE_DIR:-}
+      VALIDATION_QUERY: ${VALIDATION_QUERY:-}
       KAGGLE_API_TOKEN: ${KAGGLE_API_TOKEN:-}
     volumes:
       - .:/workspace
@@ -49,18 +55,36 @@ services:
       context: .
       dockerfile: Dockerfile
       target: runtime
+      args:
+        WITH_PROVIDERS: ${WITH_PROVIDERS:-}
     image: movie-finder-rag:runtime
     environment:
-      VECTOR_STORE: ${VECTOR_STORE:-}
+      VECTOR_STORE: ${VECTOR_STORE:-qdrant}
       VECTOR_STORE_URL: ${VECTOR_STORE_URL:-}
       VECTOR_STORE_API_KEY: ${VECTOR_STORE_API_KEY:-}
       BACKUP_COLLECTION_NAME: ${BACKUP_COLLECTION_NAME:-}
       BACKUP_OUTPUT_ROOT: ${BACKUP_OUTPUT_ROOT:-}
       BACKUP_BATCH_SIZE: ${BACKUP_BATCH_SIZE:-}
+      CHROMADB_PERSIST_PATH: ${CHROMADB_PERSIST_PATH:-}
+      PINECONE_API_KEY: ${PINECONE_API_KEY:-}
+      PINECONE_INDEX_NAME: ${PINECONE_INDEX_NAME:-}
+      PINECONE_INDEX_HOST: ${PINECONE_INDEX_HOST:-}
+      PINECONE_CLOUD: ${PINECONE_CLOUD:-}
+      PINECONE_REGION: ${PINECONE_REGION:-}
+      PGVECTOR_DSN: ${PGVECTOR_DSN:-}
+      PGVECTOR_SCHEMA: ${PGVECTOR_SCHEMA:-}
       QDRANT_URL: ${QDRANT_URL:-}
       QDRANT_API_KEY_RW: ${QDRANT_API_KEY_RW:-}
-      QDRANT_COLLECTION_NAME: ${QDRANT_COLLECTION_NAME:-movies}
+      QDRANT_COLLECTION_PREFIX: ${QDRANT_COLLECTION_PREFIX:-movies}
+      EMBEDDING_PROVIDER: ${EMBEDDING_PROVIDER:-openai}
+      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-text-embedding-3-large}
+      EMBEDDING_DIMENSIONS: ${EMBEDDING_DIMENSIONS:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
+      OLLAMA_URL: ${OLLAMA_URL:-}
+      OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
+      SENTENCE_TRANSFORMERS_CACHE_DIR: ${SENTENCE_TRANSFORMERS_CACHE_DIR:-}
+      VALIDATION_QUERY: ${VALIDATION_QUERY:-}
       KAGGLE_API_TOKEN: ${KAGGLE_API_TOKEN:-}
     restart: "no"
 

--- a/docs/devops-setup.md
+++ b/docs/devops-setup.md
@@ -64,5 +64,6 @@ After manual ingest or backup runs, the job archives:
 
 - `ingestion-outputs.env`
 - `outputs/reports/cost-report.json`
+- `outputs/reports/skipped-movies.json`
 - `outputs/reports/validation-report.json`
 - `outputs/backups/**`

--- a/docs/devops-setup.md
+++ b/docs/devops-setup.md
@@ -1,0 +1,68 @@
+# DevOps Setup
+
+This repo's Jenkins job is parameterized for the ADR 0008 provider factory contract.
+
+This repo keeps the original operational split:
+
+- PR and `main` builds run quality gates only.
+- Ingestion, validation, and backup are manual operations against configured backends.
+- All job execution stays inside Docker; local-host assumptions are out of scope.
+
+---
+
+## Parameters
+
+| Parameter | Purpose |
+| --- | --- |
+| `EMBEDDING_PROVIDER` | Selects the embedding provider |
+| `EMBEDDING_MODEL` | Selects the provider-specific embedding model |
+| `EMBEDDING_DIMENSIONS` | Optional output dimension override |
+| `EMBEDDING_API_KEY` | Optional override for OpenAI, Google, or Ollama cloud |
+| `OLLAMA_URL` | Docker-reachable Ollama URL when `EMBEDDING_PROVIDER=ollama` |
+| `COLLECTION_PREFIX` | Prefix used for ADR 0008 target naming |
+| `VECTOR_STORE` | Selects the ingestion backend |
+| `VECTOR_STORE_URL` | Optional qdrant URL override |
+| `VECTOR_STORE_API_KEY` | Optional qdrant or pinecone API key override |
+| `CHROMADB_PERSIST_PATH` | Persistent path when `VECTOR_STORE=chromadb` |
+| `PINECONE_INDEX_NAME` | Pinecone index name |
+| `PINECONE_INDEX_HOST` | Optional Pinecone host override |
+| `PINECONE_CLOUD` | Pinecone serverless cloud |
+| `PINECONE_REGION` | Pinecone serverless region |
+| `PGVECTOR_DSN_OVERRIDE` | Optional pgvector DSN override |
+| `PGVECTOR_SCHEMA` | Schema token for pgvector table derivation |
+| `WITH_PROVIDERS` | Docker build extra, typically `local` |
+| `VALIDATION_QUERY` | Smoke-test query for post-ingest validation |
+
+---
+
+## Jenkins Credentials
+
+| Credential ID | Used For |
+| --- | --- |
+| `qdrant-url` | Default `QDRANT_URL` when `VECTOR_STORE=qdrant` |
+| `qdrant-api-key-rw` | Default `QDRANT_API_KEY_RW` when `VECTOR_STORE=qdrant` |
+| `openai-api-key` | Default `OPENAI_API_KEY` when `EMBEDDING_PROVIDER=openai` |
+| `google-api-key` | Default `GOOGLE_API_KEY` when `EMBEDDING_PROVIDER=google` |
+| `ollama-api-key` | Default `OLLAMA_API_KEY` for Ollama cloud |
+| `pinecone-api-key` | Default `PINECONE_API_KEY` when `VECTOR_STORE=pinecone` |
+| `pgvector-dsn` | Default `PGVECTOR_DSN` when `VECTOR_STORE=pgvector` |
+| `kaggle-api-token` | Required dataset download token |
+
+---
+
+## Backup Scope
+
+Portable backup is implemented for every supported source backend: `qdrant`, `chromadb`,
+`pinecone`, and `pgvector`. Every backup run writes a ChromaDB artifact under `outputs/backups/`
+plus a manifest that records the source backend and the embedding runtime metadata.
+
+---
+
+## Archived Artifacts
+
+After manual ingest or backup runs, the job archives:
+
+- `ingestion-outputs.env`
+- `outputs/reports/cost-report.json`
+- `outputs/reports/validation-report.json`
+- `outputs/backups/**`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "movie-finder-rag"
 version = "0.1.0"
-description = "AI/Data ingestion pipeline — embeds Kaggle movie dataset into a Qdrant vector store"
+description = "AI/Data ingestion pipeline — embeds the Kaggle movie dataset into the configured vector store"
 license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.13"
@@ -18,12 +18,22 @@ dependencies = [
     "chromadb>=1.5.5",
     "google-genai>=1.69.0",
     "kagglehub>=1.0.0",
+    "ollama>=0.6.1",
     "openai>=2.29.0",
     "pandas>=3.0.1",
+    "pgvector>=0.4.1",
+    "pinecone>=7.0.2",
+    "psycopg[binary]>=3.2.12",
     "pydantic>=2.12.5",
     "pydantic-settings>=2.13.1",
     "qdrant-client>=1.17.1",
     "tqdm>=4.66.0",
+]
+
+[project.optional-dependencies]
+local = [
+    "sentence-transformers>=5.1.2",
+    "torch>=2.8.0",
 ]
 
 [dependency-groups]
@@ -72,10 +82,6 @@ ignore_missing_imports = true
 warn_return_any = true
 warn_unused_ignores = true
 plugins = ["pydantic.mypy"]
-
-[[tool.mypy.overrides]]
-module = "tests.*"
-disallow_untyped_defs = false
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/scripts/backup_vectorstore.py
+++ b/scripts/backup_vectorstore.py
@@ -12,7 +12,10 @@ import chromadb
 import numpy as np
 from qdrant_client import QdrantClient
 
-BACKUP_ROOT = Path("outputs/backups/chromadb")
+from rag.vectorstore.naming import sanitize_collection_token
+
+BACKUP_ROOT = Path("outputs/backups")
+INGESTION_OUTPUTS_PATH = Path("ingestion-outputs.env")
 type BackupMetadataValue = str | int | float | bool | None | list[str | int | float | bool]
 
 
@@ -33,8 +36,16 @@ class BackupConfig:
     collection_name: str
     output_root: Path
     batch_size: int
+    embedding_provider: str | None = None
+    embedding_model: str | None = None
+    embedding_dimension: int | None = None
     vector_store_url: str | None = None
     vector_store_api_key: str | None = None
+    chromadb_persist_path: str | None = None
+    pinecone_index_name: str | None = None
+    pinecone_index_host: str | None = None
+    pgvector_dsn: str | None = None
+    pgvector_schema: str = "public"
 
 
 @dataclass(slots=True)
@@ -47,6 +58,7 @@ class BackupStats:
     remote_points: int
     local_points: int
     artifact_size_bytes: int
+    manifest_path: Path
 
 
 class VectorStoreBackupSource(Protocol):
@@ -66,9 +78,7 @@ class QdrantBackupSource:
         if not config.vector_store_url:
             raise ValueError("Qdrant backup requires VECTOR_STORE_URL or QDRANT_URL.")
         if not config.vector_store_api_key:
-            raise ValueError(
-                "Qdrant backup requires VECTOR_STORE_API_KEY or QDRANT_API_KEY_RW."
-            )
+            raise ValueError("Qdrant backup requires VECTOR_STORE_API_KEY or QDRANT_API_KEY_RW.")
 
         self.config = config
         self.client = QdrantClient(
@@ -78,9 +88,7 @@ class QdrantBackupSource:
 
     def count_points(self) -> int:
         """Return the total number of Qdrant points in the configured collection."""
-        return int(
-            self.client.count(collection_name=self.config.collection_name, exact=True).count
-        )
+        return int(self.client.count(collection_name=self.config.collection_name, exact=True).count)
 
     def iter_batches(self) -> Iterator[list[BackupRecord]]:
         """Yield Qdrant points as generic backup records."""
@@ -113,6 +121,226 @@ class QdrantBackupSource:
             if next_page is None:
                 return
             offset = next_page
+
+
+class ChromaDBBackupSource:
+    """ChromaDB backup adapter used for local persistent collections."""
+
+    def __init__(self, config: BackupConfig) -> None:
+        if not config.chromadb_persist_path:
+            raise ValueError("ChromaDB backup requires CHROMADB_PERSIST_PATH.")
+
+        self.config = config
+        self.client = chromadb.PersistentClient(path=config.chromadb_persist_path)
+        self.collection = self.client.get_collection(name=config.collection_name)
+
+    def count_points(self) -> int:
+        """Return the total number of ChromaDB vectors in the configured collection."""
+        return int(self.collection.count())
+
+    def iter_batches(self) -> Iterator[list[BackupRecord]]:
+        """Yield ChromaDB points as generic backup records."""
+        offset = 0
+
+        while True:
+            response = self.collection.get(
+                limit=self.config.batch_size,
+                offset=offset,
+                include=["embeddings", "metadatas"],
+            )
+            ids = response.get("ids", [])
+            if not ids:
+                return
+
+            embeddings = cast(list[list[float]] | None, response.get("embeddings"))
+            metadatas = cast(list[dict[str, Any]] | None, response.get("metadatas"))
+            if embeddings is None or metadatas is None:
+                raise ValueError(
+                    "ChromaDB backup requires embeddings and metadatas in collection.get."
+                )
+
+            batch: list[BackupRecord] = []
+            for record_id, vector, metadata in zip(ids, embeddings, metadatas, strict=True):
+                payload_json = cast(str | None, metadata.get("payload_json"))
+                if not payload_json:
+                    raise ValueError(
+                        f"ChromaDB source record '{record_id}' is missing payload_json metadata."
+                    )
+                batch.append(
+                    BackupRecord(
+                        id=str(record_id),
+                        vector=[float(value) for value in vector],
+                        payload_json=payload_json,
+                    )
+                )
+
+            yield batch
+            offset += len(ids)
+
+
+class PineconeBackupSource:
+    """Pinecone backup adapter used for namespace-level exports."""
+
+    def __init__(self, config: BackupConfig) -> None:
+        if not config.vector_store_api_key:
+            raise ValueError("Pinecone backup requires PINECONE_API_KEY or VECTOR_STORE_API_KEY.")
+        if not config.pinecone_index_name:
+            raise ValueError("Pinecone backup requires PINECONE_INDEX_NAME.")
+
+        try:
+            from pinecone import Pinecone
+        except ImportError as exc:
+            raise RuntimeError(
+                "Pinecone backup requires the optional 'pinecone' dependency."
+            ) from exc
+
+        self.config = config
+        self.client = Pinecone(api_key=config.vector_store_api_key)
+        self.index_host = config.pinecone_index_host or config.vector_store_url
+        self.index_name = config.pinecone_index_name
+        self.namespace = config.collection_name
+        self.index = self._get_index()
+
+    def count_points(self) -> int:
+        """Return the total number of Pinecone vectors in the configured namespace."""
+        stats = self.index.describe_index_stats()
+        namespaces = getattr(stats, "namespaces", None) or stats.get("namespaces", {})
+        namespace_stats = namespaces.get(self.namespace)
+        if namespace_stats is None:
+            return 0
+        return int(
+            getattr(namespace_stats, "vector_count", None) or namespace_stats.get("vector_count", 0)
+        )
+
+    def iter_batches(self) -> Iterator[list[BackupRecord]]:
+        """Yield Pinecone vectors as generic backup records."""
+        for ids in _chunked(self._list_ids(), self.config.batch_size):
+            fetched = self.index.fetch(ids=ids, namespace=self.namespace)
+            vectors = getattr(fetched, "vectors", None) or fetched.get("vectors", {})
+            batch: list[BackupRecord] = []
+            for record_id in ids:
+                vector_record = vectors.get(record_id)
+                if vector_record is None:
+                    raise ValueError(
+                        f"Pinecone source record '{record_id}' was not returned by fetch."
+                    )
+
+                values = getattr(vector_record, "values", None) or vector_record.get("values")
+                metadata = getattr(vector_record, "metadata", None) or vector_record.get("metadata")
+                batch.append(
+                    BackupRecord(
+                        id=record_id,
+                        vector=[float(value) for value in cast(list[float], values)],
+                        payload_json=_serialize_payload(metadata, record_id),
+                    )
+                )
+
+            if batch:
+                yield batch
+
+    def _get_index(self) -> Any:
+        if self.index_host:
+            return self.client.Index(host=self.index_host)
+
+        description = self.client.describe_index(name=self.index_name)
+        host = getattr(description, "host", None) or description.get("host")
+        if not host:
+            raise ValueError(f"Unable to resolve Pinecone host for index '{self.index_name}'.")
+        return self.client.Index(host=host)
+
+    def _list_ids(self) -> list[str]:
+        list_paginated = getattr(self.index, "list_paginated", None)
+        if callable(list_paginated):
+            return self._list_ids_paginated(list_paginated)
+
+        list_vectors = getattr(self.index, "list", None)
+        if callable(list_vectors):
+            return _flatten_pinecone_ids(list_vectors(namespace=self.namespace))
+
+        raise ValueError("Pinecone backup requires an index.list or index.list_paginated API.")
+
+    def _list_ids_paginated(self, list_paginated: Any) -> list[str]:
+        collected: list[str] = []
+        pagination_token: str | None = None
+
+        while True:
+            kwargs: dict[str, Any] = {
+                "namespace": self.namespace,
+                "limit": self.config.batch_size,
+            }
+            if pagination_token:
+                kwargs["pagination_token"] = pagination_token
+            response = list_paginated(**kwargs)
+            collected.extend(_flatten_pinecone_ids(response))
+            pagination_token = _extract_pinecone_pagination_token(response)
+            if not pagination_token:
+                return collected
+
+
+class PGVectorBackupSource:
+    """PGVector backup adapter used for PostgreSQL-backed collections."""
+
+    def __init__(self, config: BackupConfig) -> None:
+        if not config.pgvector_dsn:
+            raise ValueError("PGVector backup requires PGVECTOR_DSN.")
+
+        try:
+            import psycopg
+            from pgvector.psycopg import register_vector
+        except ImportError as exc:
+            raise RuntimeError(
+                "PGVector backup requires the optional 'psycopg' and 'pgvector' dependencies."
+            ) from exc
+
+        self._psycopg = psycopg
+        self._register_vector = register_vector
+        self.config = config
+        self.table_name = sanitize_collection_token(
+            f"{config.pgvector_schema}_{config.collection_name}"
+        )
+
+    def count_points(self) -> int:
+        """Return the total number of PGVector rows in the configured table."""
+        with self._connect() as connection, connection.cursor() as cursor:
+            cursor.execute(f'SELECT COUNT(*) FROM "{self.table_name}"')
+            row = cursor.fetchone()
+            return int(row[0] if row else 0)
+
+    def iter_batches(self) -> Iterator[list[BackupRecord]]:
+        """Yield PGVector rows as generic backup records."""
+        offset = 0
+
+        while True:
+            with self._connect() as connection, connection.cursor() as cursor:
+                cursor.execute(
+                    f'''
+                    SELECT id, payload, embedding
+                    FROM "{self.table_name}"
+                    ORDER BY id
+                    LIMIT %s OFFSET %s
+                    ''',
+                    (self.config.batch_size, offset),
+                )
+                rows = cursor.fetchall()
+
+            if not rows:
+                return
+
+            batch = [
+                BackupRecord(
+                    id=str(record_id),
+                    vector=[float(value) for value in cast(list[float], vector)],
+                    payload_json=_serialize_payload(_coerce_pg_payload(payload), record_id),
+                )
+                for record_id, payload, vector in rows
+            ]
+            yield batch
+            offset += len(rows)
+
+    def _connect(self) -> Any:
+        connection = self._psycopg.connect(self.config.pgvector_dsn)
+        self._register_vector(connection)
+        return connection
 
 
 def backup() -> None:
@@ -173,6 +401,26 @@ def backup_vector_store(config: BackupConfig) -> BackupStats:
         )
 
     artifact_size_bytes = _directory_size(output_path)
+    manifest_path = output_path / "backup-manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "vector_store": config.vector_store,
+                "backup_format": "chromadb",
+                "collection_name": config.collection_name,
+                "embedding_provider": config.embedding_provider,
+                "embedding_model": config.embedding_model,
+                "embedding_dimension": config.embedding_dimension,
+                "output_path": str(output_path),
+                "remote_points": remote_points,
+                "local_points": local_points,
+                "artifact_size_bytes": artifact_size_bytes,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     logger.info(
         "Backup completed for '%s/%s': %d points saved to %s (%s, %d bytes).",
         config.vector_store,
@@ -190,6 +438,7 @@ def backup_vector_store(config: BackupConfig) -> BackupStats:
         remote_points=remote_points,
         local_points=local_points,
         artifact_size_bytes=artifact_size_bytes,
+        manifest_path=manifest_path,
     )
 
 
@@ -197,6 +446,12 @@ def build_backup_source(config: BackupConfig) -> VectorStoreBackupSource:
     """Resolve the script-local vector store adapter from the provided config."""
     if config.vector_store == "qdrant":
         return QdrantBackupSource(config)
+    if config.vector_store == "chromadb":
+        return ChromaDBBackupSource(config)
+    if config.vector_store == "pinecone":
+        return PineconeBackupSource(config)
+    if config.vector_store == "pgvector":
+        return PGVectorBackupSource(config)
 
     raise ValueError(f"Unsupported vector store for backup: {config.vector_store}")
 
@@ -204,17 +459,27 @@ def build_backup_source(config: BackupConfig) -> VectorStoreBackupSource:
 def load_config(argv: list[str] | None = None) -> BackupConfig:
     """Resolve script configuration from CLI args with CI-friendly env fallbacks."""
     vector_store = _env_or_default("VECTOR_STORE", "qdrant")
+    ingestion_outputs = _read_ingestion_outputs_env()
     collection_name = (
         _env_or_none("BACKUP_COLLECTION_NAME")
+        or _env_or_none("VECTOR_STORE_TARGET_NAME")
         or _env_or_none("QDRANT_COLLECTION_NAME")
+        or ingestion_outputs.get("VECTOR_STORE_TARGET_NAME")
+        or ingestion_outputs.get("QDRANT_COLLECTION_NAME")
         or "movies"
     )
     output_root = _env_or_default("BACKUP_OUTPUT_ROOT", str(BACKUP_ROOT))
     batch_size = int(_env_or_default("BACKUP_BATCH_SIZE", "1000"))
     vector_store_url = _env_or_none("VECTOR_STORE_URL") or _env_or_none("QDRANT_URL")
-    vector_store_api_key = _env_or_none("VECTOR_STORE_API_KEY") or _env_or_none(
-        "QDRANT_API_KEY_RW"
+    vector_store_api_key = _env_or_none("VECTOR_STORE_API_KEY") or _env_or_none("QDRANT_API_KEY_RW")
+    embedding_dimension = _env_or_none("EMBEDDING_DIMENSION") or ingestion_outputs.get(
+        "EMBEDDING_DIMENSION"
     )
+    chromadb_persist_path = _env_or_none("CHROMADB_PERSIST_PATH")
+    pinecone_index_name = _env_or_none("PINECONE_INDEX_NAME")
+    pinecone_index_host = _env_or_none("PINECONE_INDEX_HOST")
+    pgvector_dsn = _env_or_none("PGVECTOR_DSN")
+    pgvector_schema = _env_or_default("PGVECTOR_SCHEMA", "public")
 
     parser = argparse.ArgumentParser(
         description="Back up a configured vector store collection into a local ChromaDB artifact."
@@ -250,6 +515,31 @@ def load_config(argv: list[str] | None = None) -> BackupConfig:
         default=vector_store_api_key,
         help="Vector store API key.",
     )
+    parser.add_argument(
+        "--chromadb-persist-path",
+        default=chromadb_persist_path,
+        help="ChromaDB persistence path for chromadb source backups.",
+    )
+    parser.add_argument(
+        "--pinecone-index-name",
+        default=pinecone_index_name,
+        help="Pinecone index name for pinecone source backups.",
+    )
+    parser.add_argument(
+        "--pinecone-index-host",
+        default=pinecone_index_host,
+        help="Optional Pinecone index host override.",
+    )
+    parser.add_argument(
+        "--pgvector-dsn",
+        default=pgvector_dsn,
+        help="PGVector PostgreSQL DSN for pgvector source backups.",
+    )
+    parser.add_argument(
+        "--pgvector-schema",
+        default=pgvector_schema,
+        help="PGVector schema token used when deriving table names.",
+    )
 
     args = parser.parse_args(argv)
     return BackupConfig(
@@ -257,8 +547,17 @@ def load_config(argv: list[str] | None = None) -> BackupConfig:
         collection_name=args.collection_name,
         output_root=Path(args.output_root),
         batch_size=args.batch_size,
+        embedding_provider=_env_or_none("EMBEDDING_PROVIDER")
+        or ingestion_outputs.get("EMBEDDING_PROVIDER"),
+        embedding_model=_env_or_none("EMBEDDING_MODEL") or ingestion_outputs.get("EMBEDDING_MODEL"),
+        embedding_dimension=int(embedding_dimension) if embedding_dimension else None,
         vector_store_url=args.vector_store_url,
         vector_store_api_key=args.vector_store_api_key,
+        chromadb_persist_path=args.chromadb_persist_path,
+        pinecone_index_name=args.pinecone_index_name,
+        pinecone_index_host=args.pinecone_index_host,
+        pgvector_dsn=args.pgvector_dsn,
+        pgvector_schema=args.pgvector_schema,
     )
 
 
@@ -284,6 +583,20 @@ def _env_or_none(name: str) -> str | None:
 def _env_or_default(name: str, default: str) -> str:
     """Return a non-empty env var value or the provided default."""
     return _env_or_none(name) or default
+
+
+def _read_ingestion_outputs_env() -> dict[str, str]:
+    """Read ingestion outputs emitted by the pipeline when present."""
+    if not INGESTION_OUTPUTS_PATH.exists():
+        return {}
+
+    parsed: dict[str, str] = {}
+    for line in INGESTION_OUTPUTS_PATH.read_text(encoding="utf-8").splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", maxsplit=1)
+        parsed[key] = value
+    return parsed
 
 
 def _backup_path(config: BackupConfig) -> Path:
@@ -336,6 +649,73 @@ def _format_size(size_bytes: int) -> str:
         size /= 1024.0
 
     return f"{size_bytes} B"
+
+
+def _coerce_pg_payload(payload: Any) -> dict[str, Any]:
+    """Normalize PGVector JSON payload values into dictionaries."""
+    if isinstance(payload, str):
+        return cast(dict[str, Any], json.loads(payload))
+    return cast(dict[str, Any], dict(payload))
+
+
+def _chunked(values: list[str], size: int) -> Iterator[list[str]]:
+    """Yield fixed-size slices from a list."""
+    for index in range(0, len(values), size):
+        yield values[index : index + size]
+
+
+def _flatten_pinecone_ids(value: Any) -> list[str]:
+    """Collect vector IDs from Pinecone list-style responses."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Mapping):
+        if "id" in value and isinstance(value["id"], str):
+            return [value["id"]]
+        if "ids" in value:
+            return _flatten_pinecone_ids(value["ids"])
+        if "vectors" in value:
+            return _flatten_pinecone_ids(value["vectors"])
+        if "matches" in value:
+            return _flatten_pinecone_ids(value["matches"])
+        collected: list[str] = []
+        for key in ("vectors", "matches", "data", "results"):
+            nested = value.get(key)
+            if nested is None:
+                continue
+            collected.extend(_flatten_pinecone_ids(nested))
+        return collected
+    if isinstance(value, list | tuple):
+        collected = []
+        for nested in value:
+            collected.extend(_flatten_pinecone_ids(nested))
+        return collected
+    if hasattr(value, "id") and isinstance(value.id, str):
+        return [value.id]
+    if hasattr(value, "__dict__"):
+        return _flatten_pinecone_ids(vars(value))
+    return []
+
+
+def _extract_pinecone_pagination_token(response: Any) -> str | None:
+    """Extract a pagination token from a Pinecone paginated list response."""
+    pagination = getattr(response, "pagination", None)
+    if pagination is None and isinstance(response, Mapping):
+        pagination = response.get("pagination")
+    if pagination is None:
+        return None
+
+    if isinstance(pagination, Mapping):
+        token = pagination.get("next") or pagination.get("next_token") or pagination.get("token")
+        return cast(str | None, token)
+
+    return cast(
+        str | None,
+        getattr(pagination, "next", None)
+        or getattr(pagination, "next_token", None)
+        or getattr(pagination, "token", None),
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/backup_vectorstore.py
+++ b/scripts/backup_vectorstore.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -41,6 +42,7 @@ class BackupConfig:
     embedding_dimension: int | None = None
     vector_store_url: str | None = None
     vector_store_api_key: str | None = None
+    request_timeout: int | None = None
     chromadb_persist_path: str | None = None
     pinecone_index_name: str | None = None
     pinecone_index_host: str | None = None
@@ -84,6 +86,7 @@ class QdrantBackupSource:
         self.client = QdrantClient(
             url=config.vector_store_url,
             api_key=config.vector_store_api_key,
+            timeout=config.request_timeout,
         )
 
     def count_points(self) -> int:
@@ -101,6 +104,7 @@ class QdrantBackupSource:
                 offset=offset,
                 with_payload=True,
                 with_vectors=True,
+                timeout=self.config.request_timeout,
             )
 
             if not records:
@@ -338,7 +342,7 @@ class PGVectorBackupSource:
             offset += len(rows)
 
     def _connect(self) -> Any:
-        connection = self._psycopg.connect(self.config.pgvector_dsn)
+        connection = self._psycopg.connect(cast(str, self.config.pgvector_dsn))
         self._register_vector(connection)
         return connection
 
@@ -351,7 +355,7 @@ def backup() -> None:
 
 def backup_vector_store(config: BackupConfig) -> BackupStats:
     """Back up the configured vector store collection into a local ChromaDB artifact."""
-    logger = logging.getLogger("backup_script")
+    logger = logging.getLogger(__name__)
     source = build_backup_source(config)
     output_path = _backup_path(config)
 
@@ -470,6 +474,7 @@ def load_config(argv: list[str] | None = None) -> BackupConfig:
     )
     output_root = _env_or_default("BACKUP_OUTPUT_ROOT", str(BACKUP_ROOT))
     batch_size = int(_env_or_default("BACKUP_BATCH_SIZE", "1000"))
+    request_timeout_raw = _env_or_none("QDRANT_REQUEST_TIMEOUT") or _env_or_none("REQUEST_TIMEOUT")
     vector_store_url = _env_or_none("VECTOR_STORE_URL") or _env_or_none("QDRANT_URL")
     vector_store_api_key = _env_or_none("VECTOR_STORE_API_KEY") or _env_or_none("QDRANT_API_KEY_RW")
     embedding_dimension = _env_or_none("EMBEDDING_DIMENSION") or ingestion_outputs.get(
@@ -553,6 +558,7 @@ def load_config(argv: list[str] | None = None) -> BackupConfig:
         embedding_dimension=int(embedding_dimension) if embedding_dimension else None,
         vector_store_url=args.vector_store_url,
         vector_store_api_key=args.vector_store_api_key,
+        request_timeout=int(request_timeout_raw) if request_timeout_raw else None,
         chromadb_persist_path=args.chromadb_persist_path,
         pinecone_index_name=args.pinecone_index_name,
         pinecone_index_host=args.pinecone_index_host,
@@ -563,11 +569,15 @@ def load_config(argv: list[str] | None = None) -> BackupConfig:
 
 def configure_logging() -> None:
     """Configure stdlib logging for script execution."""
+    if logging.getLogger().handlers:
+        return
+
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
     logging.basicConfig(
         level=getattr(logging, log_level, logging.INFO),
         format="%(asctime)s | %(levelname)-8s | %(name)s | %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
+        stream=sys.stdout,
     )
 
 

--- a/scripts/retrieve.py
+++ b/scripts/retrieve.py
@@ -1,37 +1,25 @@
 from rag.config import settings
-from rag.embeddings.base import EmbeddingProvider
-from rag.embeddings.gemini_provider import GeminiEmbeddingProvider
-from rag.embeddings.openai_provider import OpenAIEmbeddingProvider
+from rag.embeddings.factory import get_embedding_provider
 from rag.utils.logger import get_logger
-from rag.vectorstore.qdrant_vectorstore import QdrantVectorStore
+from rag.vectorstore.factory import get_vector_store
 
 
 def interactive_retrieve() -> None:
-    """
-    Interactive CLI for developers to evaluate RAG retrieval performance.
-
-    Allows users to input natural language queries and see the top-K most
-    similar movie results from the pre-embedded Qdrant collection.
-    """
+    """Interactive CLI for developers to evaluate retrieval quality."""
     logger = get_logger("interactive_eval")
     print("\n" + "=" * 60)
     print("✨  Movie Finder RAG — Interactive Evaluation CLI  ✨")
     print("=" * 60)
     logger.info("Starting interactive retrieval session...")
 
-    # Initialize components
-    provider: EmbeddingProvider
-
-    if settings.embedding_provider == "openai":
-        provider = OpenAIEmbeddingProvider()
-    else:
-        provider = GeminiEmbeddingProvider()
-
-    store = QdrantVectorStore()
+    provider = get_embedding_provider()
+    store = get_vector_store()
     model_info = provider.model_info
+    target_name = store.target_name(model_info)
 
-    print(f"\n🔗 Connected to Qdrant collection: '{settings.qdrant_collection_name}'")
-    print(f"🤖 Using Embedding Provider: {settings.embedding_provider.upper()}")
+    print(f"\n🗂️  Vector Store: {settings.vector_store}")
+    print(f"🔗 Connected target: '{target_name}'")
+    print(f"🤖 Embedding Provider: {settings.embedding_provider.upper()}")
     print(f"📦 Model: {model_info.name} ({model_info.dimension}d)")
     print("\n💡 Type 'exit' or 'quit' to end the session.")
 
@@ -39,41 +27,44 @@ def interactive_retrieve() -> None:
         try:
             print("\n" + "-" * 40)
             query = input("🔍 Enter your movie search query: ").strip()
-
-            if query.lower() in ["exit", "quit"]:
+            if query.lower() in {"exit", "quit"}:
                 break
             if not query:
                 continue
 
             print("⏳ Embedding query and searching...")
-
-            # Embed the search query
             query_vector = provider.embed(query)
             if not query_vector:
-                print("❌ Failed to generate embedding. Please check your API keys.")
+                print("❌ Failed to generate embedding. Check provider credentials or local runtime.")
                 continue
 
-            # Perform the search
             results = store.search(query_vector, top_k=5, embedding_model=model_info)
-
-            # Display results
             if not results:
-                print("🤷 No matching movies found in the vector store.")
-            else:
-                print(f"\n🍿 Top {len(results)} matching movies:")
-                for idx, movie in enumerate(results, 1):
-                    print(f"\n{idx}. 🎬 {movie.title} ({movie.release_year})")
-                    print(f"   👤 Director: {movie.director}")
-                    print(f"   🎭 Genre:    {', '.join(movie.genre)}")
-                    print(f"   👥 Cast:     {', '.join(movie.cast[:5])}...")
-                    print(f"   📝 Snippet:  {movie.plot[:250]}...")
-                    print("   " + "." * 10)
+                print("🤷 No matching movies found.")
+                continue
+
+            print(f"\n🍿 Top {len(results)} matching movies:")
+            for index, movie in enumerate(results, start=1):
+                cast_preview = ", ".join(movie.cast[:5])
+                if len(movie.cast) > 5:
+                    cast_preview += "..."
+
+                plot_preview = movie.plot[:250]
+                if len(movie.plot) > 250:
+                    plot_preview += "..."
+
+                print(f"\n{index}. 🎬 {movie.title} ({movie.release_year})")
+                print(f"   👤 Director: {movie.director}")
+                print(f"   🎭 Genre:    {', '.join(movie.genre)}")
+                print(f"   👥 Cast:     {cast_preview}")
+                print(f"   📝 Snippet:  {plot_preview}")
+                print("   " + "." * 10)
 
         except KeyboardInterrupt:
             break
-        except Exception as e:
-            logger.error(f"Error during retrieval: {e}")
-            print(f"💥 An unexpected error occurred: {e}")
+        except Exception as exc:
+            logger.error("Error during retrieval: %s", exc)
+            print(f"💥 An unexpected error occurred: {exc}")
 
     print("\n" + "=" * 60)
     print("👋 Session ended. Happy finding! 🍿")

--- a/scripts/retrieve.py
+++ b/scripts/retrieve.py
@@ -35,7 +35,9 @@ def interactive_retrieve() -> None:
             print("⏳ Embedding query and searching...")
             query_vector = provider.embed(query)
             if not query_vector:
-                print("❌ Failed to generate embedding. Check provider credentials or local runtime.")
+                print(
+                    "❌ Failed to generate embedding. Check provider credentials or local runtime."
+                )
                 continue
 
             results = store.search(query_vector, top_k=5, embedding_model=model_info)

--- a/scripts/validate_ingestion.py
+++ b/scripts/validate_ingestion.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+from rag.config import settings
+from rag.embeddings.factory import get_embedding_provider
+from rag.vectorstore.factory import get_vector_store
+
+REPORT_PATH = Path("outputs/reports/validation-report.json")
+
+
+def validate() -> None:
+    """Run a post-ingest smoke validation and persist a machine-readable report."""
+    provider = get_embedding_provider()
+    vector_store = get_vector_store()
+    model_info = provider.model_info
+    target_name = vector_store.target_name(model_info)
+    point_count = vector_store.count(model_info)
+
+    query_vector = provider.embed(settings.validation_query)
+    results = []
+    if query_vector:
+        results = vector_store.search(query_vector, top_k=3, embedding_model=model_info)
+
+    status = "passed" if point_count > 0 and bool(results) else "failed"
+    report = {
+        "status": status,
+        "embedding_provider": settings.embedding_provider,
+        "embedding_model": model_info.name,
+        "embedding_dimension": model_info.dimension,
+        "vector_store": settings.vector_store,
+        "target_name": target_name,
+        "point_count": point_count,
+        "validation_query": settings.validation_query,
+        "result_count": len(results),
+        "top_result": results[0].title if results else None,
+    }
+
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    if status != "passed":
+        raise SystemExit(
+            f"Validation failed for target '{target_name}'. "
+            f"point_count={point_count}, result_count={len(results)}."
+        )
+
+
+if __name__ == "__main__":
+    validate()

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -1,3 +1,4 @@
+import os
 import re
 from typing import Any, Literal, cast
 
@@ -21,6 +22,7 @@ DEFAULT_EMBEDDING_MODELS: dict[EmbeddingProviderName, str] = {
     "google": "text-embedding-004",
 }
 DEFAULT_VALIDATION_QUERY = "A time-travel movie with a scientist and a DeLorean"
+DEFAULT_ENV_FILE = os.getenv("RAG_ENV_FILE", ".env")
 
 KNOWN_MODEL_DIMENSIONS: dict[EmbeddingProviderName, dict[str, int]] = {
     "openai": {
@@ -83,7 +85,11 @@ def infer_embedding_dimension(provider: EmbeddingProviderName, model: str) -> in
 class RAGConfig(BaseSettings):
     """Project-wide settings and configuration managed by Pydantic."""
 
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+    model_config = SettingsConfigDict(
+        env_file=DEFAULT_ENV_FILE,
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
 
     qdrant_url: str | None = Field(None, validation_alias="QDRANT_URL")
     qdrant_api_key_rw: str | None = Field(None, validation_alias="QDRANT_API_KEY_RW")

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -1,48 +1,230 @@
-from typing import Literal
+import re
+from typing import Any, Literal, cast
 
-from pydantic import Field
+from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+EmbeddingProviderName = Literal[
+    "openai",
+    "ollama",
+    "huggingface",
+    "sentence-transformers",
+    "google",
+]
+VectorStoreName = Literal["qdrant", "chromadb", "pinecone", "pgvector"]
+
+DEFAULT_EMBEDDING_MODELS: dict[EmbeddingProviderName, str] = {
+    "openai": "text-embedding-3-large",
+    "ollama": "bge-m3",
+    "huggingface": "BAAI/bge-m3",
+    "sentence-transformers": "BAAI/bge-m3",
+    "google": "text-embedding-004",
+}
+DEFAULT_VALIDATION_QUERY = "A time-travel movie with a scientist and a DeLorean"
+
+KNOWN_MODEL_DIMENSIONS: dict[EmbeddingProviderName, dict[str, int]] = {
+    "openai": {
+        "text-embedding-3-small": 1536,
+        "text-embedding-3-large": 3072,
+        "text-embedding-ada-002": 1536,
+    },
+    "ollama": {
+        "all-minilm": 384,
+        "all-minilm:latest": 384,
+        "bge-m3": 1024,
+        "bge-m3:latest": 1024,
+        "embeddinggemma": 768,
+        "embeddinggemma:latest": 768,
+        "mxbai-embed-large": 1024,
+        "mxbai-embed-large:latest": 1024,
+        "nomic-embed-text": 768,
+        "nomic-embed-text:latest": 768,
+    },
+    "sentence-transformers": {
+        "BAAI/bge-m3": 1024,
+        "sentence-transformers/all-MiniLM-L6-v2": 384,
+        "sentence-transformers/all-mpnet-base-v2": 768,
+    },
+    "huggingface": {
+        "BAAI/bge-m3": 1024,
+        "sentence-transformers/all-MiniLM-L6-v2": 384,
+        "sentence-transformers/all-mpnet-base-v2": 768,
+    },
+    "google": {
+        "text-embedding-004": 768,
+    },
+}
+
+_COLLECTION_PREFIX_RE = re.compile(r"^[a-z0-9_]+$")
+_PINECONE_INDEX_NAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,43}[a-z0-9])?$")
+_LEGACY_TOKEN_RE = re.compile(r"[\/.\-\s]+")
+_INVALID_TOKEN_RE = re.compile(r"[^a-z0-9_]+")
+_MULTI_UNDERSCORE_RE = re.compile(r"_+")
+
+
+def infer_embedding_dimension(provider: EmbeddingProviderName, model: str) -> int:
+    """Best-effort embedding dimension lookup for config and reporting."""
+    known_dimension = KNOWN_MODEL_DIMENSIONS.get(provider, {}).get(model)
+    if known_dimension is not None:
+        return known_dimension
+
+    if provider == "openai":
+        if "large" in model:
+            return 3072
+        if "small" in model or "ada" in model:
+            return 1536
+
+    if provider == "google":
+        return 768
+
+    return 0
 
 
 class RAGConfig(BaseSettings):
-    """
-    Project-wide settings and configuration managed by Pydantic.
-    """
+    """Project-wide settings and configuration managed by Pydantic."""
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
-    # Qdrant Cloud (Write-capable key required for ingestion)
-    qdrant_url: str = Field(..., validation_alias="QDRANT_URL")
-    qdrant_api_key_rw: str = Field(..., validation_alias="QDRANT_API_KEY_RW")
-    qdrant_collection_name: str = Field("movies", validation_alias="QDRANT_COLLECTION_NAME")
-
-    # OpenAI Embeddings
-    openai_api_key: str = Field(..., validation_alias="OPENAI_API_KEY")
-    openai_embedding_model: str = Field(
-        "text-embedding-3-large", validation_alias="OPENAI_EMBEDDING_MODEL"
+    qdrant_url: str | None = Field(None, validation_alias="QDRANT_URL")
+    qdrant_api_key_rw: str | None = Field(None, validation_alias="QDRANT_API_KEY_RW")
+    qdrant_collection_prefix: str = Field(
+        "movies",
+        validation_alias=AliasChoices("QDRANT_COLLECTION_PREFIX", "QDRANT_COLLECTION_NAME"),
     )
 
-    # Gemini Embeddings
+    vector_store: VectorStoreName = Field("qdrant", validation_alias="VECTOR_STORE")
+    vector_store_url: str | None = Field(None, validation_alias="VECTOR_STORE_URL")
+    vector_store_api_key: str | None = Field(None, validation_alias="VECTOR_STORE_API_KEY")
+    chromadb_persist_path: str = Field(
+        "outputs/chromadb/local", validation_alias="CHROMADB_PERSIST_PATH"
+    )
+    pinecone_api_key: str | None = Field(
+        None, validation_alias=AliasChoices("PINECONE_API_KEY", "VECTOR_STORE_API_KEY")
+    )
+    pinecone_index_name: str = Field("movie-finder-rag", validation_alias="PINECONE_INDEX_NAME")
+    pinecone_index_host: str | None = Field(None, validation_alias="PINECONE_INDEX_HOST")
+    pinecone_cloud: str = Field("aws", validation_alias="PINECONE_CLOUD")
+    pinecone_region: str = Field("us-east-1", validation_alias="PINECONE_REGION")
+    pgvector_dsn: str | None = Field(
+        None, validation_alias=AliasChoices("PGVECTOR_DSN", "VECTOR_STORE_URL")
+    )
+    pgvector_schema: str = Field("public", validation_alias="PGVECTOR_SCHEMA")
+
+    embedding_provider: EmbeddingProviderName = Field(
+        "openai", validation_alias="EMBEDDING_PROVIDER"
+    )
+    embedding_model: str = Field(
+        DEFAULT_EMBEDDING_MODELS["openai"], validation_alias="EMBEDDING_MODEL"
+    )
+    embedding_dimensions: int | None = Field(None, validation_alias="EMBEDDING_DIMENSIONS", ge=1)
+    openai_api_key: str | None = Field(None, validation_alias="OPENAI_API_KEY")
     google_api_key: str | None = Field(None, validation_alias="GOOGLE_API_KEY")
-    gemini_embedding_model: str = Field(
-        "text-embedding-004", validation_alias="GEMINI_EMBEDDING_MODEL"
+    ollama_url: str | None = Field(None, validation_alias="OLLAMA_URL")
+    ollama_api_key: str | None = Field(None, validation_alias="OLLAMA_API_KEY")
+    sentence_transformers_cache_dir: str | None = Field(
+        None, validation_alias="SENTENCE_TRANSFORMERS_CACHE_DIR"
     )
 
-    # Ingestion Configuration
-    batch_size: int = 100
-    embedding_provider: Literal["openai", "gemini"] = "openai"
-
-    # Kaggle Configuration
+    batch_size: int = Field(100, validation_alias="BATCH_SIZE", ge=1, le=10_000)
+    validation_query: str = Field(
+        DEFAULT_VALIDATION_QUERY,
+        validation_alias="VALIDATION_QUERY",
+    )
     kaggle_api_token: str | None = Field(None, validation_alias="KAGGLE_API_TOKEN")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _apply_dynamic_defaults(cls, values: Any) -> Any:
+        """Populate provider-dependent defaults before field validation."""
+        if not isinstance(values, dict):
+            return values
+
+        normalized = dict(values)
+        provider = normalized.get("EMBEDDING_PROVIDER") or normalized.get("embedding_provider")
+        if not isinstance(provider, str) or not provider.strip():
+            provider = "openai"
+        provider = provider.strip()
+        if provider not in DEFAULT_EMBEDDING_MODELS:
+            provider = "openai"
+        model = normalized.get("EMBEDDING_MODEL") or normalized.get("embedding_model")
+        dimensions = normalized.get("EMBEDDING_DIMENSIONS", normalized.get("embedding_dimensions"))
+        validation_query = normalized.get("VALIDATION_QUERY", normalized.get("validation_query"))
+
+        if not isinstance(model, str) or not model.strip():
+            provider_name = cast(EmbeddingProviderName, provider)
+            normalized["EMBEDDING_MODEL"] = DEFAULT_EMBEDDING_MODELS[provider_name]
+        if isinstance(dimensions, str) and not dimensions.strip():
+            normalized["EMBEDDING_DIMENSIONS"] = None
+        if not isinstance(validation_query, str) or not validation_query.strip():
+            normalized["VALIDATION_QUERY"] = DEFAULT_VALIDATION_QUERY
+
+        return normalized
+
+    @field_validator("embedding_model", "validation_query")
+    @classmethod
+    def _validate_non_empty_text(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Value must not be empty.")
+        return cleaned
+
+    @field_validator("qdrant_collection_prefix")
+    @classmethod
+    def _validate_collection_prefix(cls, value: str) -> str:
+        cleaned = value.strip().lower()
+        cleaned = _LEGACY_TOKEN_RE.sub("_", cleaned)
+        cleaned = _INVALID_TOKEN_RE.sub("_", cleaned)
+        cleaned = _MULTI_UNDERSCORE_RE.sub("_", cleaned).strip("_")
+        if not cleaned:
+            raise ValueError("QDRANT_COLLECTION_PREFIX must not be empty.")
+        if not _COLLECTION_PREFIX_RE.fullmatch(cleaned):
+            raise ValueError(
+                "QDRANT_COLLECTION_PREFIX must contain only lowercase letters, digits, and underscores."
+            )
+        return cleaned
+
+    @model_validator(mode="after")
+    def _validate_runtime_shape(self) -> "RAGConfig":
+        """Validate cross-field provider and vector-store requirements."""
+        if self.embedding_provider == "openai" and not self.openai_api_key:
+            raise ValueError("OPENAI_API_KEY is required when EMBEDDING_PROVIDER=openai.")
+
+        if self.embedding_provider == "google" and not self.google_api_key:
+            raise ValueError("GOOGLE_API_KEY is required when EMBEDDING_PROVIDER=google.")
+
+        if self.embedding_provider == "ollama" and not self.ollama_url:
+            raise ValueError("OLLAMA_URL is required when EMBEDDING_PROVIDER=ollama.")
+
+        if self.embedding_provider == "google" and self.embedding_dimensions is not None:
+            raise ValueError(
+                "EMBEDDING_DIMENSIONS is not supported when EMBEDDING_PROVIDER=google."
+            )
+
+        if self.vector_store == "qdrant":
+            if not self.qdrant_url:
+                raise ValueError("QDRANT_URL is required when VECTOR_STORE=qdrant.")
+            if not self.qdrant_api_key_rw:
+                raise ValueError("QDRANT_API_KEY_RW is required when VECTOR_STORE=qdrant.")
+
+        if self.vector_store == "pinecone":
+            if not self.pinecone_api_key:
+                raise ValueError("PINECONE_API_KEY is required when VECTOR_STORE=pinecone.")
+            if not _PINECONE_INDEX_NAME_RE.fullmatch(self.pinecone_index_name):
+                raise ValueError(
+                    "PINECONE_INDEX_NAME must be 1-45 chars, lowercase alphanumeric or '-'."
+                )
+
+        if self.vector_store == "pgvector" and not self.pgvector_dsn:
+            raise ValueError("PGVECTOR_DSN is required when VECTOR_STORE=pgvector.")
+
+        return self
 
     @property
     def embedding_dimension(self) -> int:
-        """Returns the dimension of the configured embedding model."""
-        if self.embedding_provider == "openai":
-            if self.openai_embedding_model == "text-embedding-3-large":
-                return 3072
-            return 1536
-        return 768
+        """Return the configured embedding model dimension when it is known."""
+        if self.embedding_dimensions is not None:
+            return self.embedding_dimensions
+        return infer_embedding_dimension(self.embedding_provider, self.embedding_model)
 
 
 settings = RAGConfig()

--- a/src/rag/embeddings/base.py
+++ b/src/rag/embeddings/base.py
@@ -4,10 +4,7 @@ from pydantic import BaseModel
 
 
 class EmbeddingModelMetadata(BaseModel):
-    """
-    Standardized metadata for any embedding model, regardless of provider.
-    Includes dimensions and pricing for cost tracking.
-    """
+    """Standardized metadata for any embedding model, regardless of provider."""
 
     name: str
     dimension: int
@@ -15,9 +12,7 @@ class EmbeddingModelMetadata(BaseModel):
 
 
 class EmbeddingModelUsage(BaseModel):
-    """
-    Usage statistics and estimated cost for an embedding run.
-    """
+    """Usage statistics and estimated cost for an embedding run."""
 
     prompt_tokens: int = 0
     total_tokens: int = 0
@@ -25,48 +20,21 @@ class EmbeddingModelUsage(BaseModel):
 
 
 class EmbeddingProvider(ABC):
-    """
-    Abstract base class for embedding providers (e.g., OpenAI, Gemini).
-    """
+    """Abstract base class for embedding providers."""
 
     @property
     @abstractmethod
     def model_info(self) -> EmbeddingModelMetadata:
         """Return standardized metadata about the current model."""
-        pass
 
     @abstractmethod
     def embed(self, text: str) -> list[float]:
-        """
-        Embed a single string of text into a vector.
-
-        Args:
-            text (str): The text string to embed.
-
-        Returns:
-            list[float]: The generated embedding vector.
-        """
-        pass
+        """Embed a single string of text into a vector."""
 
     @abstractmethod
     def embed_batch(self, texts: list[str]) -> list[list[float]]:
-        """
-        Embed a batch of strings into vectors.
-
-        Args:
-            texts (list[str]): The list of text strings to embed.
-
-        Returns:
-            list[list[float]]: The list of generated embedding vectors.
-        """
-        pass
+        """Embed a batch of strings into vectors."""
 
     @abstractmethod
     def get_model_usage(self) -> EmbeddingModelUsage:
-        """
-        Return the cumulative usage and cost for the current session.
-
-        Returns:
-            EmbeddingModelUsage: The usage statistics for the current provider instance.
-        """
-        pass
+        """Return the cumulative usage and cost for the current session."""

--- a/src/rag/embeddings/factory.py
+++ b/src/rag/embeddings/factory.py
@@ -1,0 +1,35 @@
+from collections.abc import Callable
+from functools import lru_cache
+
+from rag.config import EmbeddingProviderName, settings
+from rag.embeddings.base import EmbeddingProvider
+from rag.embeddings.gemini_provider import GeminiEmbeddingProvider
+from rag.embeddings.ollama_provider import OllamaEmbeddingProvider
+from rag.embeddings.openai_provider import OpenAIEmbeddingProvider
+from rag.embeddings.sentence_transformers_provider import SentenceTransformersEmbeddingProvider
+
+ProviderBuilder = Callable[[str | None], EmbeddingProvider]
+
+_PROVIDERS: dict[EmbeddingProviderName, ProviderBuilder] = {
+    "openai": lambda model: OpenAIEmbeddingProvider(model=model),
+    "ollama": lambda model: OllamaEmbeddingProvider(model=model),
+    "huggingface": lambda model: SentenceTransformersEmbeddingProvider(model=model),
+    "sentence-transformers": lambda model: SentenceTransformersEmbeddingProvider(model=model),
+    "google": lambda model: GeminiEmbeddingProvider(model=model),
+}
+
+
+def create_embedding_provider(
+    provider_name: EmbeddingProviderName | None = None,
+    model: str | None = None,
+) -> EmbeddingProvider:
+    """Instantiate the configured embedding provider without caching."""
+    resolved_provider = provider_name or settings.embedding_provider
+    provider_builder = _PROVIDERS[resolved_provider]
+    return provider_builder(model)
+
+
+@lru_cache(maxsize=1)
+def get_embedding_provider() -> EmbeddingProvider:
+    """Return the configured embedding provider as a process singleton."""
+    return create_embedding_provider()

--- a/src/rag/embeddings/gemini_provider.py
+++ b/src/rag/embeddings/gemini_provider.py
@@ -2,75 +2,62 @@ from typing import cast
 
 from google import genai
 
-from rag.config import settings
-from rag.embeddings.base import (
-    EmbeddingModelMetadata,
-    EmbeddingModelUsage,
-    EmbeddingProvider,
-)
+from rag.config import infer_embedding_dimension, settings
+from rag.embeddings.base import EmbeddingModelMetadata, EmbeddingModelUsage, EmbeddingProvider
 from rag.utils.logger import get_logger
 
 
 class GeminiEmbeddingProvider(EmbeddingProvider):
-    """
-    Google Gemini-specific embedding provider.
-    """
+    """Google Gemini embedding provider."""
 
-    # Model metadata map
     MODELS: dict[str, EmbeddingModelMetadata] = {
         "text-embedding-004": EmbeddingModelMetadata(
             name="text-embedding-004", dimension=768, cost_per_1k_tokens=0.0
         ),
     }
 
-    def __init__(self, model: str = settings.gemini_embedding_model) -> None:
-        """Initialize the Gemini provider using settings."""
+    def __init__(self, model: str | None = None) -> None:
         self.logger = get_logger(self.__class__.__name__)
-        self.model = model
+        self.model = model or settings.embedding_model
 
         if not settings.google_api_key:
             raise ValueError("GOOGLE_API_KEY is not defined in settings")
+        if settings.embedding_dimensions is not None:
+            raise ValueError("GOOGLE embeddings do not support EMBEDDING_DIMENSIONS in this repo.")
 
         self.client = genai.Client(api_key=settings.google_api_key)
         self._usage = EmbeddingModelUsage()
 
     @property
     def model_info(self) -> EmbeddingModelMetadata:
-        """Metadata for the current Gemini model."""
         metadata = self.MODELS.get(self.model)
-        if metadata:
+        if metadata is not None:
             return metadata
 
-        return EmbeddingModelMetadata(
-            name=self.model,
-            dimension=768,  # Default for Gemini text-embedding-004
-            cost_per_1k_tokens=0.0,
-        )
+        dimension = infer_embedding_dimension("google", self.model)
+        if dimension <= 0:
+            raise ValueError(
+                f"Unknown Google embedding dimension for model '{self.model}'. "
+                "Add the model to the metadata map before using it for ingestion."
+            )
+
+        return EmbeddingModelMetadata(name=self.model, dimension=dimension, cost_per_1k_tokens=0.0)
 
     def embed(self, text: str) -> list[float]:
-        """Generate an embedding for a single text using Gemini."""
-        try:
-            response = self.client.models.embed_content(model=self.model, contents=[text])
-            if not response.embeddings:
-                return []
-
-            return cast(list[float], response.embeddings[0].values)
-        except Exception as e:
-            self.logger.error(f"Error calling Gemini API: {e}")
-            return []
+        vectors = self.embed_batch([text])
+        return vectors[0] if vectors else []
 
     def embed_batch(self, texts: list[str]) -> list[list[float]]:
-        """Generate embeddings for multiple texts in a single batch call."""
         try:
             response = self.client.models.embed_content(model=self.model, contents=texts)
             if not response.embeddings:
                 return []
-
-            return [cast(list[float], emb.values) for emb in response.embeddings]
-        except Exception as e:
-            self.logger.error(f"Error calling Gemini API for batch: {e}")
+            self._usage.prompt_tokens += len(texts)
+            self._usage.total_tokens += len(texts)
+            return [cast(list[float], embedding.values) for embedding in response.embeddings]
+        except Exception as exc:
+            self.logger.error("Error calling Gemini embedding API: %s", exc)
             return []
 
     def get_model_usage(self) -> EmbeddingModelUsage:
-        """Returns the calculated tokens and estimated cost."""
         return self._usage

--- a/src/rag/embeddings/ollama_provider.py
+++ b/src/rag/embeddings/ollama_provider.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from rag.config import infer_embedding_dimension, settings
 from rag.embeddings.base import EmbeddingModelMetadata, EmbeddingModelUsage, EmbeddingProvider
 from rag.utils.logger import get_logger
@@ -49,7 +51,7 @@ class OllamaEmbeddingProvider(EmbeddingProvider):
 
     def embed_batch(self, texts: list[str]) -> list[list[float]]:
         try:
-            request: dict[str, object] = {"model": self.model, "input": texts}
+            request: dict[str, Any] = {"model": self.model, "input": texts}
             if self.dimensions is not None:
                 request["dimensions"] = self.dimensions
             response = self.client.embed(**request)

--- a/src/rag/embeddings/ollama_provider.py
+++ b/src/rag/embeddings/ollama_provider.py
@@ -1,0 +1,65 @@
+from rag.config import infer_embedding_dimension, settings
+from rag.embeddings.base import EmbeddingModelMetadata, EmbeddingModelUsage, EmbeddingProvider
+from rag.utils.logger import get_logger
+
+
+class OllamaEmbeddingProvider(EmbeddingProvider):
+    """Ollama embedding provider for local and cloud-hosted Ollama models."""
+
+    def __init__(self, model: str | None = None) -> None:
+        self.logger = get_logger(self.__class__.__name__)
+        self.model = model or settings.embedding_model
+        self.dimensions = settings.embedding_dimensions
+        self._usage = EmbeddingModelUsage()
+
+        try:
+            from ollama import Client
+        except ImportError as exc:
+            raise RuntimeError(
+                "Ollama support requires the optional provider dependencies. "
+                "Set WITH_PROVIDERS=local when building the Docker image."
+            ) from exc
+
+        headers = None
+        if settings.ollama_api_key:
+            headers = {"Authorization": f"Bearer {settings.ollama_api_key}"}
+        self.client = Client(host=settings.ollama_url, headers=headers)
+
+    @property
+    def model_info(self) -> EmbeddingModelMetadata:
+        dimension = self.dimensions or infer_embedding_dimension("ollama", self.model)
+        if dimension <= 0:
+            try:
+                response = self.client.embed(model=self.model, input=["dimension probe"])
+                embeddings = response.get("embeddings", [])
+                if embeddings:
+                    dimension = len(embeddings[0])
+            except Exception as exc:
+                self.logger.error("Unable to probe Ollama embedding dimension: %s", exc)
+        if dimension <= 0:
+            raise ValueError(
+                f"Unknown Ollama embedding dimension for model '{self.model}'. "
+                "Add the model to the metadata map before using it for ingestion."
+            )
+        return EmbeddingModelMetadata(name=self.model, dimension=dimension, cost_per_1k_tokens=0.0)
+
+    def embed(self, text: str) -> list[float]:
+        embeddings = self.embed_batch([text])
+        return embeddings[0] if embeddings else []
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        try:
+            request: dict[str, object] = {"model": self.model, "input": texts}
+            if self.dimensions is not None:
+                request["dimensions"] = self.dimensions
+            response = self.client.embed(**request)
+            embeddings = response.get("embeddings", [])
+            self._usage.total_tokens += int(response.get("prompt_eval_count", 0))
+            self._usage.prompt_tokens = self._usage.total_tokens
+            return [list(cast_embedding) for cast_embedding in embeddings]
+        except Exception as exc:
+            self.logger.error("Error calling Ollama embedding API: %s", exc)
+            return []
+
+    def get_model_usage(self) -> EmbeddingModelUsage:
+        return self._usage

--- a/src/rag/embeddings/openai_provider.py
+++ b/src/rag/embeddings/openai_provider.py
@@ -1,23 +1,14 @@
-from typing import Any
-
 from openai import OpenAI
 from openai.types.create_embedding_response import Usage
 
-from rag.config import settings
-from rag.embeddings.base import (
-    EmbeddingModelMetadata,
-    EmbeddingModelUsage,
-    EmbeddingProvider,
-)
+from rag.config import infer_embedding_dimension, settings
+from rag.embeddings.base import EmbeddingModelMetadata, EmbeddingModelUsage, EmbeddingProvider
 from rag.utils.logger import get_logger
 
 
 class OpenAIEmbeddingProvider(EmbeddingProvider):
-    """
-    OpenAI-specific embedding provider implementing cost and usage tracking.
-    """
+    """OpenAI embedding provider with usage and cost tracking."""
 
-    # Authoritative model map using universal metadata structure
     MODELS: dict[str, EmbeddingModelMetadata] = {
         "text-embedding-3-small": EmbeddingModelMetadata(
             name="text-embedding-3-small", dimension=1536, cost_per_1k_tokens=0.00002
@@ -30,20 +21,10 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         ),
     }
 
-    def __init__(self, model: str = settings.openai_embedding_model) -> None:
-        """Initialize the OpenAI provider using settings.
-
-        Args:
-            model (str): The OpenAI model name to use.
-        """
+    def __init__(self, model: str | None = None) -> None:
         self.logger = get_logger(self.__class__.__name__)
-        self.model = model
-
-        if self.model not in self.MODELS:
-            self.logger.warning(
-                f"Model '{self.model}' is not in the authoritative metadata map. "
-                "Usage and cost tracking may be inaccurate."
-            )
+        self.model = model or settings.embedding_model
+        self.dimensions = settings.embedding_dimensions
 
         if not settings.openai_api_key:
             raise ValueError("OPENAI_API_KEY is not defined in settings")
@@ -53,52 +34,47 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
 
     @property
     def model_info(self) -> EmbeddingModelMetadata:
-        """Return the standardized model metadata."""
         metadata = self.MODELS.get(self.model)
-        if metadata:
+        if metadata is not None:
+            if self.dimensions is not None:
+                return metadata.model_copy(update={"dimension": self.dimensions})
             return metadata
 
-        return EmbeddingModelMetadata(
-            name=self.model, dimension=settings.embedding_dimension, cost_per_1k_tokens=0.0
-        )
+        dimension = self.dimensions or infer_embedding_dimension("openai", self.model)
+        if dimension <= 0:
+            raise ValueError(
+                f"Unknown OpenAI embedding dimension for model '{self.model}'. "
+                "Add the model to the metadata map before using it for ingestion."
+            )
 
-    def embed(self, text: str) -> list[float] | Any:
-        """Generate an embedding for a single string of text."""
-        try:
-            response = self.client.embeddings.create(model=self.model, input=text)
-            self._update_usage(response.usage)
-            return response.data[0].embedding
-        except Exception as e:
-            self.logger.error(f"Error calling OpenAI API: {e}")
-            return []
+        return EmbeddingModelMetadata(name=self.model, dimension=dimension, cost_per_1k_tokens=0.0)
+
+    def embed(self, text: str) -> list[float]:
+        vectors = self.embed_batch([text])
+        return vectors[0] if vectors else []
 
     def embed_batch(self, texts: list[str]) -> list[list[float]]:
-        """Generate embeddings for a batch of strings."""
         try:
-            response = self.client.embeddings.create(model=self.model, input=texts)
+            if self.dimensions is not None:
+                response = self.client.embeddings.create(
+                    model=self.model,
+                    input=texts,
+                    dimensions=self.dimensions,
+                )
+            else:
+                response = self.client.embeddings.create(model=self.model, input=texts)
             self._update_usage(response.usage)
             return [data.embedding for data in response.data]
-        except Exception as e:
-            self.logger.error(f"Error calling OpenAI API for batch: {e}")
+        except Exception as exc:
+            self.logger.error("Error calling OpenAI embeddings API: %s", exc)
             return []
 
     def get_model_usage(self) -> EmbeddingModelUsage:
-        """Return cumulative usage and estimated cost for this instance."""
         return self._usage
 
     def _update_usage(self, usage: Usage) -> None:
-        """Calculate cost and update usage statistics."""
         metadata = self.MODELS.get(self.model)
         cost_per_1k = metadata.cost_per_1k_tokens if metadata else 0.0
-
         self._usage.prompt_tokens += usage.prompt_tokens
         self._usage.total_tokens += usage.total_tokens
-
-        # Calculate USD cost: (tokens / 1000) * price_per_1k
-        incremental_cost = (usage.total_tokens / 1000) * cost_per_1k
-        self._usage.estimated_cost_usd += incremental_cost
-
-        self.logger.debug(
-            f"Model: {self.model} | Total Tokens: {self._usage.total_tokens} | "
-            f"Est. Cost: ${self._usage.estimated_cost_usd:.5f}"
-        )
+        self._usage.estimated_cost_usd += (usage.total_tokens / 1000) * cost_per_1k

--- a/src/rag/embeddings/sentence_transformers_provider.py
+++ b/src/rag/embeddings/sentence_transformers_provider.py
@@ -1,0 +1,62 @@
+from typing import cast
+
+from rag.config import infer_embedding_dimension, settings
+from rag.embeddings.base import EmbeddingModelMetadata, EmbeddingModelUsage, EmbeddingProvider
+from rag.utils.logger import get_logger
+
+
+class SentenceTransformersEmbeddingProvider(EmbeddingProvider):
+    """Sentence-Transformers provider for offline local development."""
+
+    def __init__(self, model: str | None = None) -> None:
+        self.logger = get_logger(self.__class__.__name__)
+        self.model = model or settings.embedding_model
+        self.dimensions = settings.embedding_dimensions
+        self._usage = EmbeddingModelUsage()
+
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError as exc:
+            raise RuntimeError(
+                "Sentence-Transformers support requires the optional provider dependencies. "
+                "Set WITH_PROVIDERS=local when building the Docker image."
+            ) from exc
+
+        self.client = SentenceTransformer(
+            self.model,
+            cache_folder=settings.sentence_transformers_cache_dir,
+        )
+
+    @property
+    def model_info(self) -> EmbeddingModelMetadata:
+        dimension = int(self.client.get_sentence_embedding_dimension() or 0)
+        if self.dimensions is not None:
+            dimension = self.dimensions
+        elif dimension <= 0:
+            dimension = infer_embedding_dimension("sentence-transformers", self.model)
+        if dimension <= 0:
+            raise ValueError(
+                f"Unable to resolve embedding dimension for sentence-transformers model '{self.model}'."
+            )
+        return EmbeddingModelMetadata(name=self.model, dimension=dimension, cost_per_1k_tokens=0.0)
+
+    def embed(self, text: str) -> list[float]:
+        embeddings = self.embed_batch([text])
+        return embeddings[0] if embeddings else []
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        try:
+            vectors = self.client.encode(
+                texts,
+                convert_to_numpy=True,
+                truncate_dim=self.dimensions,
+            )
+            self._usage.prompt_tokens += len(texts)
+            self._usage.total_tokens += len(texts)
+            return cast(list[list[float]], vectors.tolist())
+        except Exception as exc:
+            self.logger.error("Error generating sentence-transformers embeddings: %s", exc)
+            return []
+
+    def get_model_usage(self) -> EmbeddingModelUsage:
+        return self._usage

--- a/src/rag/ingestion/pipeline.py
+++ b/src/rag/ingestion/pipeline.py
@@ -1,17 +1,64 @@
 import json
 from pathlib import Path
+from typing import Any
 
 from tqdm import tqdm
 
 from rag.config import settings
 from rag.embeddings.base import EmbeddingProvider
 from rag.ingestion import csv_loader
+from rag.models.movie import Movie
 from rag.utils.logger import get_logger
 from rag.vectorstore.base import VectorStore
 
 _OUTPUT_ENV_PATH = Path("ingestion-outputs.env")
 _REPORT_DIR = Path("outputs/reports")
 _COST_REPORT_PATH = _REPORT_DIR / "cost-report.json"
+_SKIPPED_MOVIES_REPORT_PATH = _REPORT_DIR / "skipped-movies.json"
+
+
+def _embed_batch_with_fallback(
+    movies: list[Movie],
+    embedding_provider: EmbeddingProvider,
+) -> tuple[list[Movie], list[list[float]], list[dict[str, Any]]]:
+    """Embed a batch, falling back to per-movie embedding when batch calls fail."""
+    logger = get_logger(__name__)
+    vectors = embedding_provider.embed_batch([movie.plot for movie in movies])
+
+    if len(vectors) == len(movies):
+        return movies, vectors, []
+
+    logger.warning(
+        "Batch embedding returned %d vectors for %d movies. Falling back to per-movie embedding.",
+        len(vectors),
+        len(movies),
+    )
+
+    embedded_movies: list[Movie] = []
+    embedded_vectors: list[list[float]] = []
+    skipped_movies: list[dict[str, Any]] = []
+    for movie in movies:
+        vector = embedding_provider.embed(movie.plot)
+        if not vector:
+            skipped_movie = {
+                "id": movie.id,
+                "title": movie.title,
+                "release_year": movie.release_year,
+                "plot_chars": len(movie.plot),
+                "reason": "embedding_failed_after_batch_fallback",
+            }
+            logger.error(
+                "Skipping movie id=%s title=%r because embedding failed. plot_chars=%d",
+                movie.id,
+                movie.title,
+                len(movie.plot),
+            )
+            skipped_movies.append(skipped_movie)
+            continue
+        embedded_movies.append(movie)
+        embedded_vectors.append(vector)
+
+    return embedded_movies, embedded_vectors, skipped_movies
 
 
 def ingest_csv(embedding_provider: EmbeddingProvider, vector_store: VectorStore) -> None:
@@ -35,23 +82,39 @@ def ingest_csv(embedding_provider: EmbeddingProvider, vector_store: VectorStore)
         target_name,
     )
 
+    inserted_movie_count = 0
+    skipped_movies: list[dict[str, Any]] = []
     for start in tqdm(range(0, len(movies), batch_size), desc="Ingesting Movies"):
         batch = movies[start : start + batch_size]
-        vectors = embedding_provider.embed_batch([movie.plot for movie in batch])
+        embedded_movies, vectors, batch_skipped_movies = _embed_batch_with_fallback(
+            batch, embedding_provider
+        )
+        skipped_movies.extend(batch_skipped_movies)
         if not vectors:
             logger.error(
                 "Failed to generate embeddings for batch %d. Skipping.", start // batch_size
             )
             continue
-        vector_store.upsert_batch(batch, vectors, model_info)
+        vector_store.upsert_batch(embedded_movies, vectors, model_info)
+        inserted_movie_count += len(embedded_movies)
 
     usage = embedding_provider.get_model_usage()
     logger.info("INGESTION COMPLETE")
     logger.info("Total Movies Processed : %d", len(movies))
+    logger.info("Total Movies Inserted  : %d", inserted_movie_count)
+    logger.info("Total Movies Skipped   : %d", len(skipped_movies))
     logger.info("Total Prompt Tokens    : %d", usage.prompt_tokens)
     logger.info("Estimated USD Cost     : $%.5f", usage.estimated_cost_usd)
 
     _write_ingestion_outputs(target_name, model_info.name, model_info.dimension, usage)
+    _write_skipped_movies_report(
+        target_name=target_name,
+        model_name=model_info.name,
+        model_dimension=model_info.dimension,
+        loaded_movie_count=len(movies),
+        inserted_movie_count=inserted_movie_count,
+        skipped_movies=skipped_movies,
+    )
 
 
 def _write_ingestion_outputs(
@@ -96,6 +159,36 @@ def _write_ingestion_outputs(
                 "prompt_tokens": prompt_tokens,
                 "total_tokens": total_tokens,
                 "estimated_cost_usd": estimated_cost_usd,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_skipped_movies_report(
+    target_name: str,
+    model_name: str,
+    model_dimension: int,
+    loaded_movie_count: int,
+    inserted_movie_count: int,
+    skipped_movies: list[dict[str, Any]],
+) -> None:
+    """Persist a machine-readable report for movies skipped during ingestion."""
+    _REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    _SKIPPED_MOVIES_REPORT_PATH.write_text(
+        json.dumps(
+            {
+                "embedding_provider": settings.embedding_provider,
+                "embedding_model": model_name,
+                "embedding_dimension": model_dimension,
+                "vector_store": settings.vector_store,
+                "target_name": target_name,
+                "loaded_movie_count": loaded_movie_count,
+                "inserted_movie_count": inserted_movie_count,
+                "skipped_movie_count": len(skipped_movies),
+                "skipped_movies": skipped_movies,
             },
             indent=2,
         )

--- a/src/rag/ingestion/pipeline.py
+++ b/src/rag/ingestion/pipeline.py
@@ -1,3 +1,6 @@
+import json
+from pathlib import Path
+
 from tqdm import tqdm
 
 from rag.config import settings
@@ -6,58 +9,96 @@ from rag.ingestion import csv_loader
 from rag.utils.logger import get_logger
 from rag.vectorstore.base import VectorStore
 
+_OUTPUT_ENV_PATH = Path("ingestion-outputs.env")
+_REPORT_DIR = Path("outputs/reports")
+_COST_REPORT_PATH = _REPORT_DIR / "cost-report.json"
 
-def ingest_csv(
-    embedding_provider: EmbeddingProvider,
-    vector_store: VectorStore,
-) -> None:
-    """
-    Orchestrates the offline RAG ingestion pipeline.
 
-    Workflow:
-    1. Load and filter CSV
-    2. Batch movies
-    3. Call batch embedding
-    4. Upsert to VectorStore
-
-    Args:
-        embedding_provider (EmbeddingProvider): The provider instance (e.g. OpenAI).
-        vector_store (VectorStore): The vector store target (e.g. Qdrant).
-    """
+def ingest_csv(embedding_provider: EmbeddingProvider, vector_store: VectorStore) -> None:
+    """Orchestrate the offline RAG ingestion pipeline."""
     logger = get_logger(__name__)
-
-    logger.info("Initializing RAG ingestion pipeline...")
+    logger.info("Initializing RAG ingestion pipeline")
     movies = csv_loader.load_movies()
-
     if not movies:
         logger.warning("No movies found to ingest. Pipeline finished.")
         return
 
-    logger.info(f"Loaded {len(movies)} movies. Starting batched embedding and ingestion...")
-
     batch_size = settings.batch_size
     model_info = embedding_provider.model_info
+    target_name = vector_store.target_name(model_info)
 
-    # Progress bar and batched processing for efficiency
-    for i in tqdm(range(0, len(movies), batch_size), desc="Ingesting Movies"):
-        batch = movies[i : i + batch_size]
-        batch_texts = [movie.plot for movie in batch]
+    logger.info(
+        "Loaded %d movies. provider=%s model=%s target=%s",
+        len(movies),
+        settings.embedding_provider,
+        model_info.name,
+        target_name,
+    )
 
-        # Call batch embedding via the provider
-        vectors = embedding_provider.embed_batch(batch_texts)
-
+    for start in tqdm(range(0, len(movies), batch_size), desc="Ingesting Movies"):
+        batch = movies[start : start + batch_size]
+        vectors = embedding_provider.embed_batch([movie.plot for movie in batch])
         if not vectors:
-            logger.error(f"Failed to generate embeddings for batch {i // batch_size}. Skipping.")
+            logger.error(
+                "Failed to generate embeddings for batch %d. Skipping.", start // batch_size
+            )
             continue
-
-        # Upsert the batch into the vector store
         vector_store.upsert_batch(batch, vectors, model_info)
 
-    # Reporting final usage and estimated cost
     usage = embedding_provider.get_model_usage()
-    logger.info("=" * 60)
     logger.info("INGESTION COMPLETE")
-    logger.info(f"Total Movies Processed : {len(movies)}")
-    logger.info(f"Total Prompt Tokens    : {usage.prompt_tokens}")
-    logger.info(f"Estimated USD Cost     : ${usage.estimated_cost_usd:.5f}")
-    logger.info("=" * 60)
+    logger.info("Total Movies Processed : %d", len(movies))
+    logger.info("Total Prompt Tokens    : %d", usage.prompt_tokens)
+    logger.info("Estimated USD Cost     : $%.5f", usage.estimated_cost_usd)
+
+    _write_ingestion_outputs(target_name, model_info.name, model_info.dimension, usage)
+
+
+def _write_ingestion_outputs(
+    target_name: str,
+    model_name: str,
+    dimension: int,
+    usage: object,
+) -> None:
+    """Persist CI-friendly ingestion outputs and cost report artifacts."""
+    prompt_tokens = int(getattr(usage, "prompt_tokens", 0))
+    total_tokens = int(getattr(usage, "total_tokens", 0))
+    estimated_cost_usd = float(getattr(usage, "estimated_cost_usd", 0.0))
+
+    _OUTPUT_ENV_PATH.write_text(
+        "\n".join(
+            [
+                f"EMBEDDING_PROVIDER={settings.embedding_provider}",
+                f"EMBEDDING_MODEL={model_name}",
+                f"EMBEDDING_DIMENSION={dimension}",
+                f"VECTOR_STORE={settings.vector_store}",
+                f"VECTOR_STORE_TARGET_NAME={target_name}",
+                f"QDRANT_COLLECTION_NAME={target_name}",
+                f"INGESTION_PROMPT_TOKENS={prompt_tokens}",
+                f"INGESTION_TOTAL_TOKENS={total_tokens}",
+                f"INGESTION_ESTIMATED_COST_USD={estimated_cost_usd:.8f}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    _REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    _COST_REPORT_PATH.write_text(
+        json.dumps(
+            {
+                "embedding_provider": settings.embedding_provider,
+                "embedding_model": model_name,
+                "embedding_dimension": dimension,
+                "vector_store": settings.vector_store,
+                "target_name": target_name,
+                "collection_name": target_name,
+                "prompt_tokens": prompt_tokens,
+                "total_tokens": total_tokens,
+                "estimated_cost_usd": estimated_cost_usd,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )

--- a/src/rag/main.py
+++ b/src/rag/main.py
@@ -1,44 +1,24 @@
-from rag.config import settings
 from rag.dataset import dataset
-from rag.embeddings.base import EmbeddingProvider
-from rag.embeddings.gemini_provider import GeminiEmbeddingProvider
-from rag.embeddings.openai_provider import OpenAIEmbeddingProvider
+from rag.embeddings.factory import get_embedding_provider
 from rag.ingestion import pipeline
 from rag.utils.logger import configure_logging, get_logger
-from rag.vectorstore.qdrant_vectorstore import QdrantVectorStore
+from rag.vectorstore.factory import get_vector_store
 
-# Bootstrap logging before any logger is obtained.
-# Reads LOG_LEVEL and LOG_FORMAT from the environment.
 configure_logging()
-
 logger = get_logger(__name__)
 
 
 def main() -> None:
-    """Entrypoint for the offline RAG ingestion pipeline.
-
-    Resolves configuration via Pydantic and triggers the ingestion flow.
-    """
-    # 1. Download data from Kaggle if not present
+    """Entrypoint for the offline RAG ingestion pipeline."""
     dataset.download_data()
-
-    # 2. Resolve embedding provider based on runtime settings
-    embedding_provider: EmbeddingProvider
-
-    if settings.embedding_provider == "openai":
-        logger.info("Using OpenAI provider with model: %s", settings.openai_embedding_model)
-        embedding_provider = OpenAIEmbeddingProvider()
-    elif settings.embedding_provider == "gemini":
-        logger.info("Using Gemini provider with model: %s", settings.gemini_embedding_model)
-        embedding_provider = GeminiEmbeddingProvider()
-    else:
-        logger.error("Unsupported embedding provider: %s", settings.embedding_provider)
-        return
-
-    # 3. Initialize vector store (Qdrant Cloud)
-    vector_store = QdrantVectorStore()
-
-    # 4. Trigger the ingestion pipeline
+    embedding_provider = get_embedding_provider()
+    vector_store = get_vector_store()
+    logger.info(
+        "Starting ingestion with provider=%s model=%s vector_store=%s",
+        embedding_provider.__class__.__name__,
+        embedding_provider.model_info.name,
+        vector_store.__class__.__name__,
+    )
     pipeline.ingest_csv(embedding_provider, vector_store)
 
 

--- a/src/rag/vectorstore/base.py
+++ b/src/rag/vectorstore/base.py
@@ -5,23 +5,21 @@ from rag.models.movie import Movie
 
 
 class VectorStore(ABC):
-    """
-    Abstract interface for vector database operations (e.g., Qdrant, ChromaDB).
-    """
+    """Abstract interface for vector database operations."""
+
+    @abstractmethod
+    def target_name(self, embedding_model: EmbeddingModelMetadata) -> str:
+        """Return the concrete target name for the provided embedding model."""
+
+    @abstractmethod
+    def count(self, embedding_model: EmbeddingModelMetadata) -> int:
+        """Return the number of stored records for the provided embedding model."""
 
     @abstractmethod
     def upsert(
         self, movie: Movie, vector: list[float], embedding_model: EmbeddingModelMetadata
     ) -> None:
-        """
-        Upsert a single movie and its vector into the store.
-
-        Args:
-            movie (Movie): The Movie object to store.
-            vector (list[float]): The embedding vector.
-            embedding_model (EmbeddingModelMetadata): Metadata about the model used.
-        """
-        pass
+        """Upsert a single movie and its vector into the store."""
 
     @abstractmethod
     def upsert_batch(
@@ -30,15 +28,7 @@ class VectorStore(ABC):
         vectors: list[list[float]],
         embedding_model: EmbeddingModelMetadata,
     ) -> None:
-        """
-        Upsert multiple movies and their vectors into the store.
-
-        Args:
-            movies (list[Movie]): The list of Movie objects.
-            vectors (list[list[float]]): The list of vectors.
-            embedding_model (EmbeddingModelMetadata): Metadata about the model used.
-        """
-        pass
+        """Upsert multiple movies and their vectors into the store."""
 
     @abstractmethod
     def search(
@@ -47,15 +37,4 @@ class VectorStore(ABC):
         top_k: int,
         embedding_model: EmbeddingModelMetadata,
     ) -> list[Movie]:
-        """
-        Perform a vector similarity search.
-
-        Args:
-            query_vector (list[float]): The query vector.
-            top_k (int): Number of top results to return.
-            embedding_model (EmbeddingModelMetadata): Metadata about the model used.
-
-        Returns:
-            list[Movie]: The top-K similar movies.
-        """
-        pass
+        """Perform a vector similarity search."""

--- a/src/rag/vectorstore/chromadb_vectorstore.py
+++ b/src/rag/vectorstore/chromadb_vectorstore.py
@@ -1,34 +1,32 @@
 import chromadb
 import numpy as np
 
+from rag.config import settings
 from rag.embeddings.base import EmbeddingModelMetadata
 from rag.models.movie import Movie
 from rag.utils.logger import get_logger
 from rag.vectorstore.base import VectorStore
+from rag.vectorstore.naming import resolve_collection_name
 
 
 class ChromaDBVectorStore(VectorStore):
-    """
-    Local vector store implementation using ChromaDB for developer use and backups.
-    """
+    """Local ChromaDB vector store implementation."""
 
     def __init__(self) -> None:
-        """Initialize the local ChromaDB client."""
         self.logger = get_logger(self.__class__.__name__)
-        self.client = chromadb.Client()
+        self.client = chromadb.PersistentClient(path=settings.chromadb_persist_path)
+
+    def target_name(self, embedding_model: EmbeddingModelMetadata) -> str:
+        return resolve_collection_name(settings.qdrant_collection_prefix, embedding_model)
+
+    def count(self, embedding_model: EmbeddingModelMetadata) -> int:
+        collection = self.client.get_or_create_collection(name=self.target_name(embedding_model))
+        return int(collection.count())
 
     def upsert(
         self, movie: Movie, vector: list[float], embedding_model: EmbeddingModelMetadata
     ) -> None:
-        """Upsert a single movie into the local ChromaDB collection."""
-        collection = self.client.get_or_create_collection(
-            name=embedding_model.name.replace("/", "-")
-        )
-        collection.add(
-            ids=[str(movie.id)],
-            embeddings=np.asarray(vector),
-            metadatas=[movie.model_dump()],
-        )
+        self.upsert_batch([movie], [vector], embedding_model)
 
     def upsert_batch(
         self,
@@ -36,14 +34,11 @@ class ChromaDBVectorStore(VectorStore):
         vectors: list[list[float]],
         embedding_model: EmbeddingModelMetadata,
     ) -> None:
-        """Upsert multiple movies into the local ChromaDB collection in a batch."""
-        collection = self.client.get_or_create_collection(
-            name=embedding_model.name.replace("/", "-")
-        )
-        collection.add(
-            ids=[str(m.id) for m in movies],
-            embeddings=np.asarray(vectors),
-            metadatas=[m.model_dump() for m in movies],
+        collection = self.client.get_or_create_collection(name=self.target_name(embedding_model))
+        collection.upsert(
+            ids=[str(movie.id) for movie in movies],
+            embeddings=np.asarray(vectors, dtype=np.float32),
+            metadatas=[movie.model_dump() for movie in movies],
         )
 
     def search(
@@ -52,14 +47,12 @@ class ChromaDBVectorStore(VectorStore):
         top_k: int,
         embedding_model: EmbeddingModelMetadata,
     ) -> list[Movie]:
-        """Perform a local vector search using ChromaDB."""
-        collection = self.client.get_or_create_collection(
-            name=embedding_model.name.replace("/", "-")
+        collection = self.client.get_or_create_collection(name=self.target_name(embedding_model))
+        results = collection.query(
+            query_embeddings=np.asarray([query_vector], dtype=np.float32),
+            n_results=top_k,
         )
-        results = collection.query(query_embeddings=np.asarray(query_vector), n_results=top_k)
-
-        movies = []
-        if results["metadatas"]:
-            for metadata in results["metadatas"][0]:
-                movies.append(Movie(**metadata))
-        return movies
+        metadatas = results.get("metadatas", [])
+        if not metadatas:
+            return []
+        return [Movie(**metadata) for metadata in metadatas[0] if metadata]

--- a/src/rag/vectorstore/factory.py
+++ b/src/rag/vectorstore/factory.py
@@ -1,0 +1,28 @@
+from functools import lru_cache
+
+from rag.config import VectorStoreName, settings
+from rag.vectorstore.base import VectorStore
+from rag.vectorstore.chromadb_vectorstore import ChromaDBVectorStore
+from rag.vectorstore.pgvector_vectorstore import PGVectorStore
+from rag.vectorstore.pinecone_vectorstore import PineconeVectorStore
+from rag.vectorstore.qdrant_vectorstore import QdrantVectorStore
+
+_VECTOR_STORES: dict[VectorStoreName, type[VectorStore]] = {
+    "qdrant": QdrantVectorStore,
+    "chromadb": ChromaDBVectorStore,
+    "pinecone": PineconeVectorStore,
+    "pgvector": PGVectorStore,
+}
+
+
+def create_vector_store(vector_store_name: VectorStoreName | None = None) -> VectorStore:
+    """Instantiate the configured vector store without caching."""
+    resolved_vector_store = vector_store_name or settings.vector_store
+    store_cls = _VECTOR_STORES[resolved_vector_store]
+    return store_cls()
+
+
+@lru_cache(maxsize=1)
+def get_vector_store() -> VectorStore:
+    """Return the configured vector store as a process singleton."""
+    return create_vector_store()

--- a/src/rag/vectorstore/naming.py
+++ b/src/rag/vectorstore/naming.py
@@ -1,0 +1,22 @@
+import re
+
+from rag.embeddings.base import EmbeddingModelMetadata
+
+_SANITIZE_PATTERN = re.compile(r"[\/.\-\s]+")
+_INVALID_PATTERN = re.compile(r"[^a-z0-9_]+")
+_MULTI_UNDERSCORE_PATTERN = re.compile(r"_+")
+
+
+def sanitize_collection_token(value: str) -> str:
+    """Return the ADR 0008-compliant token for model and collection naming."""
+    normalized = _SANITIZE_PATTERN.sub("_", value.strip().lower())
+    normalized = _INVALID_PATTERN.sub("_", normalized)
+    normalized = _MULTI_UNDERSCORE_PATTERN.sub("_", normalized)
+    return normalized.strip("_")
+
+
+def resolve_collection_name(prefix: str, embedding_model: EmbeddingModelMetadata) -> str:
+    """Resolve the zero-collision collection name shared with the chain repo."""
+    sanitized_prefix = sanitize_collection_token(prefix)
+    sanitized_model = sanitize_collection_token(embedding_model.name)
+    return f"{sanitized_prefix}_{sanitized_model}_{embedding_model.dimension}"

--- a/src/rag/vectorstore/pgvector_vectorstore.py
+++ b/src/rag/vectorstore/pgvector_vectorstore.py
@@ -90,7 +90,7 @@ class PGVectorStore(VectorStore):
         return [Movie(**cast_payload(row[0])) for row in rows]
 
     def _connect(self) -> Any:
-        connection = self._psycopg.connect(settings.pgvector_dsn)
+        connection = self._psycopg.connect(cast(str, settings.pgvector_dsn))
         self._register_vector(connection)
         return connection
 

--- a/src/rag/vectorstore/pgvector_vectorstore.py
+++ b/src/rag/vectorstore/pgvector_vectorstore.py
@@ -1,0 +1,120 @@
+import json
+from typing import Any, cast
+
+from rag.config import settings
+from rag.embeddings.base import EmbeddingModelMetadata
+from rag.models.movie import Movie
+from rag.utils.logger import get_logger
+from rag.vectorstore.base import VectorStore
+from rag.vectorstore.naming import resolve_collection_name, sanitize_collection_token
+
+
+class PGVectorStore(VectorStore):
+    """PostgreSQL pgvector-backed vector store."""
+
+    def __init__(self) -> None:
+        self.logger = get_logger(self.__class__.__name__)
+        if not settings.pgvector_dsn:
+            raise ValueError("PGVECTOR_DSN is not defined in settings")
+
+        try:
+            import psycopg
+            from pgvector.psycopg import register_vector
+        except ImportError as exc:
+            raise RuntimeError(
+                "PGVector support requires the optional 'psycopg' and 'pgvector' dependencies."
+            ) from exc
+
+        self._psycopg = psycopg
+        self._register_vector = register_vector
+
+    def target_name(self, embedding_model: EmbeddingModelMetadata) -> str:
+        return resolve_collection_name(settings.qdrant_collection_prefix, embedding_model)
+
+    def count(self, embedding_model: EmbeddingModelMetadata) -> int:
+        table_name = self._table_name(embedding_model)
+        with self._connect() as connection, connection.cursor() as cursor:
+            cursor.execute(f'SELECT COUNT(*) FROM "{table_name}"')
+            row = cursor.fetchone()
+            return int(row[0] if row else 0)
+
+    def upsert(
+        self, movie: Movie, vector: list[float], embedding_model: EmbeddingModelMetadata
+    ) -> None:
+        self.upsert_batch([movie], [vector], embedding_model)
+
+    def upsert_batch(
+        self,
+        movies: list[Movie],
+        vectors: list[list[float]],
+        embedding_model: EmbeddingModelMetadata,
+    ) -> None:
+        table_name = self._table_name(embedding_model)
+        self._ensure_table(table_name, embedding_model.dimension)
+
+        with self._connect() as connection, connection.cursor() as cursor:
+            for movie, vector in zip(movies, vectors, strict=True):
+                cursor.execute(
+                    f'''
+                    INSERT INTO "{table_name}" (id, payload, embedding)
+                    VALUES (%s, %s::jsonb, %s)
+                    ON CONFLICT (id) DO UPDATE
+                    SET payload = EXCLUDED.payload,
+                        embedding = EXCLUDED.embedding
+                    ''',
+                    (movie.id, json.dumps(movie.model_dump()), vector),
+                )
+            connection.commit()
+
+    def search(
+        self,
+        query_vector: list[float],
+        top_k: int,
+        embedding_model: EmbeddingModelMetadata,
+    ) -> list[Movie]:
+        table_name = self._table_name(embedding_model)
+        self._ensure_table(table_name, embedding_model.dimension)
+
+        with self._connect() as connection, connection.cursor() as cursor:
+            cursor.execute(
+                f'''
+                SELECT payload
+                FROM "{table_name}"
+                ORDER BY embedding <=> %s
+                LIMIT %s
+                ''',
+                (query_vector, top_k),
+            )
+            rows = cursor.fetchall()
+
+        return [Movie(**cast_payload(row[0])) for row in rows]
+
+    def _connect(self) -> Any:
+        connection = self._psycopg.connect(settings.pgvector_dsn)
+        self._register_vector(connection)
+        return connection
+
+    def _ensure_table(self, table_name: str, dimension: int) -> None:
+        with self._connect() as connection, connection.cursor() as cursor:
+            cursor.execute("CREATE EXTENSION IF NOT EXISTS vector")
+            cursor.execute(
+                f'''
+                CREATE TABLE IF NOT EXISTS "{table_name}" (
+                    id BIGINT PRIMARY KEY,
+                    payload JSONB NOT NULL,
+                    embedding vector({dimension}) NOT NULL
+                )
+                '''
+            )
+            connection.commit()
+
+    def _table_name(self, embedding_model: EmbeddingModelMetadata) -> str:
+        target_name = self.target_name(embedding_model)
+        return sanitize_collection_token(f"{settings.pgvector_schema}_{target_name}")
+
+
+def cast_payload(payload: Any) -> dict[str, Any]:
+    """Normalize psycopg payload values into Movie-ready dictionaries."""
+    if isinstance(payload, str):
+        return cast(dict[str, Any], json.loads(payload))
+    return cast(dict[str, Any], dict(payload))

--- a/src/rag/vectorstore/pinecone_vectorstore.py
+++ b/src/rag/vectorstore/pinecone_vectorstore.py
@@ -1,0 +1,118 @@
+from typing import Any, cast
+
+from rag.config import settings
+from rag.embeddings.base import EmbeddingModelMetadata
+from rag.models.movie import Movie
+from rag.utils.logger import get_logger
+from rag.vectorstore.base import VectorStore
+from rag.vectorstore.naming import resolve_collection_name
+
+
+class PineconeVectorStore(VectorStore):
+    """Pinecone-backed vector store."""
+
+    def __init__(self) -> None:
+        self.logger = get_logger(self.__class__.__name__)
+        if not settings.pinecone_api_key:
+            raise ValueError("PINECONE_API_KEY is not defined in settings")
+
+        try:
+            from pinecone import Pinecone, ServerlessSpec
+        except ImportError as exc:
+            raise RuntimeError(
+                "Pinecone support requires the optional 'pinecone' dependency."
+            ) from exc
+
+        self._serverless_spec_cls = ServerlessSpec
+        self.client = Pinecone(api_key=settings.pinecone_api_key)
+        self.index_name = settings.pinecone_index_name
+        self.index_host = settings.pinecone_index_host
+        self._index: Any | None = None
+
+    def target_name(self, embedding_model: EmbeddingModelMetadata) -> str:
+        return resolve_collection_name(settings.qdrant_collection_prefix, embedding_model)
+
+    def count(self, embedding_model: EmbeddingModelMetadata) -> int:
+        index = self._get_index(embedding_model)
+        namespace = self.target_name(embedding_model)
+        stats = index.describe_index_stats()
+        namespaces = getattr(stats, "namespaces", None) or stats.get("namespaces", {})
+        namespace_stats = namespaces.get(namespace)
+        if namespace_stats is None:
+            return 0
+        return int(
+            getattr(namespace_stats, "vector_count", None) or namespace_stats.get("vector_count", 0)
+        )
+
+    def upsert(
+        self, movie: Movie, vector: list[float], embedding_model: EmbeddingModelMetadata
+    ) -> None:
+        self.upsert_batch([movie], [vector], embedding_model)
+
+    def upsert_batch(
+        self,
+        movies: list[Movie],
+        vectors: list[list[float]],
+        embedding_model: EmbeddingModelMetadata,
+    ) -> None:
+        index = self._get_index(embedding_model)
+        namespace = self.target_name(embedding_model)
+        records = [
+            {
+                "id": str(movie.id),
+                "values": vector,
+                "metadata": movie.model_dump(),
+            }
+            for movie, vector in zip(movies, vectors, strict=True)
+        ]
+        index.upsert(namespace=namespace, vectors=records)
+
+    def search(
+        self,
+        query_vector: list[float],
+        top_k: int,
+        embedding_model: EmbeddingModelMetadata,
+    ) -> list[Movie]:
+        index = self._get_index(embedding_model)
+        namespace = self.target_name(embedding_model)
+        response = index.query(
+            namespace=namespace,
+            vector=query_vector,
+            top_k=top_k,
+            include_metadata=True,
+        )
+        matches = getattr(response, "matches", None) or response.get("matches", [])
+        results: list[Movie] = []
+        for match in matches:
+            metadata = getattr(match, "metadata", None) or match.get("metadata")
+            if metadata:
+                results.append(Movie(**cast(dict[str, Any], metadata)))
+        return results
+
+    def _get_index(self, embedding_model: EmbeddingModelMetadata) -> Any:
+        if self._index is not None:
+            return self._index
+
+        if not self.index_host:
+            self._ensure_index(embedding_model)
+            description = self.client.describe_index(name=self.index_name)
+            self.index_host = getattr(description, "host", None) or description.get("host")
+
+        self._index = self.client.Index(host=self.index_host)
+        return self._index
+
+    def _ensure_index(self, embedding_model: EmbeddingModelMetadata) -> None:
+        if self.client.has_index(self.index_name):
+            return
+
+        self.logger.info("Creating Pinecone index %s", self.index_name)
+        self.client.create_index(
+            name=self.index_name,
+            vector_type="dense",
+            dimension=embedding_model.dimension,
+            metric="cosine",
+            spec=self._serverless_spec_cls(
+                cloud=settings.pinecone_cloud,
+                region=settings.pinecone_region,
+            ),
+        )

--- a/src/rag/vectorstore/qdrant_vectorstore.py
+++ b/src/rag/vectorstore/qdrant_vectorstore.py
@@ -6,45 +6,34 @@ from rag.embeddings.base import EmbeddingModelMetadata
 from rag.models.movie import Movie
 from rag.utils.logger import get_logger
 from rag.vectorstore.base import VectorStore
+from rag.vectorstore.naming import resolve_collection_name
 
 
 class QdrantVectorStoreError(Exception):
-    """Custom exception for Qdrant VectorStore operations."""
-
-    pass
+    """Custom exception for Qdrant vector store operations."""
 
 
 class QdrantVectorStore(VectorStore):
-    """
-    Qdrant-specific implementation of the VectorStore interface.
-    Integrates with Qdrant Cloud via Pydantic settings.
-    """
+    """Qdrant-backed vector store."""
 
     def __init__(self) -> None:
-        """Initialize the Qdrant client using settings.
-
-        Raises:
-            QdrantVectorStoreError: If environment configuration is missing.
-        """
         self.logger = get_logger(self.__class__.__name__)
-
         self._validate_env()
-
         self.client = QdrantClient(url=settings.qdrant_url, api_key=settings.qdrant_api_key_rw)
+
+    def target_name(self, embedding_model: EmbeddingModelMetadata) -> str:
+        return resolve_collection_name(settings.qdrant_collection_prefix, embedding_model)
+
+    def count(self, embedding_model: EmbeddingModelMetadata) -> int:
+        collection_name = self.target_name(embedding_model)
+        if not self.client.collection_exists(collection_name):
+            return 0
+        return int(self.client.count(collection_name=collection_name, exact=True).count)
 
     def upsert(
         self, movie: Movie, vector: list[float], embedding_model: EmbeddingModelMetadata
     ) -> None:
-        """Upsert a single movie vector into Qdrant."""
-        collection_name = self._collection_name(embedding_model)
-        self._validate_collection(embedding_model, collection_name)
-
-        point = PointStruct(
-            id=movie.id,
-            vector=vector,
-            payload=movie.model_dump(),
-        )
-        self.client.upsert(collection_name=collection_name, points=[point])
+        self.upsert_batch([movie], [vector], embedding_model)
 
     def upsert_batch(
         self,
@@ -52,19 +41,12 @@ class QdrantVectorStore(VectorStore):
         vectors: list[list[float]],
         embedding_model: EmbeddingModelMetadata,
     ) -> None:
-        """Upsert multiple movie vectors into Qdrant in a single call."""
-        collection_name = self._collection_name(embedding_model)
+        collection_name = self.target_name(embedding_model)
         self._validate_collection(embedding_model, collection_name)
-
-        points = []
-        for movie, vector in zip(movies, vectors, strict=True):
-            point = PointStruct(
-                id=movie.id,
-                vector=vector,
-                payload=movie.model_dump(),
-            )
-            points.append(point)
-
+        points = [
+            PointStruct(id=movie.id, vector=vector, payload=movie.model_dump())
+            for movie, vector in zip(movies, vectors, strict=True)
+        ]
         self.client.upsert(collection_name=collection_name, points=points)
 
     def search(
@@ -73,45 +55,31 @@ class QdrantVectorStore(VectorStore):
         top_k: int,
         embedding_model: EmbeddingModelMetadata,
     ) -> list[Movie]:
-        """Perform a vector search in Qdrant and return Movie objects."""
-        collection_name = self._collection_name(embedding_model)
+        collection_name = self.target_name(embedding_model)
         self._validate_collection(embedding_model, collection_name)
-
         results = self.client.query_points(
             collection_name=collection_name,
             query=query_vector,
             with_payload=True,
             limit=top_k,
         )
-
-        movies = []
-        for result in results.points:
-            if result.payload:
-                movies.append(Movie(**result.payload))
-
-        return movies
+        return [Movie(**point.payload) for point in results.points if point.payload]
 
     def _validate_collection(
         self, embedding_model: EmbeddingModelMetadata, collection_name: str
     ) -> None:
-        """Ensure the target collection exists with correct dimensions."""
         if not self.client.collection_exists(collection_name):
-            self.logger.info(f"Creating collection for {collection_name}")
+            self.logger.info("Creating Qdrant collection %s", collection_name)
             self.client.create_collection(
                 collection_name=collection_name,
                 vectors_config=VectorParams(
-                    size=embedding_model.dimension, distance=Distance.COSINE
+                    size=embedding_model.dimension,
+                    distance=Distance.COSINE,
                 ),
             )
 
-    def _collection_name(self, embedding_model: EmbeddingModelMetadata) -> str:
-        """Resolve the collection name from settings or embedding model name."""
-        return settings.qdrant_collection_name or embedding_model.name.replace("/", "-")
-
     def _validate_env(self) -> None:
-        """Validate required settings exist."""
         if not settings.qdrant_api_key_rw:
             raise QdrantVectorStoreError("QDRANT_API_KEY_RW is not defined in settings")
-
         if not settings.qdrant_url:
             raise QdrantVectorStoreError("QDRANT_URL is not defined in settings")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,11 @@
 import os
 
-# Keep pytest isolated from the developer's local runtime configuration.
-# The application still defaults to `.env` outside tests.
-os.environ.setdefault("RAG_ENV_FILE", ".env.pytest-do-not-load")
+# Keep pytest isolated from developer and CI runtime configuration.
+# Pydantic reads process env before env files, so these must override values
+# injected by Docker Compose from a local `.env`.
+os.environ["RAG_ENV_FILE"] = ".env.pytest-do-not-load"
+os.environ["VECTOR_STORE"] = "qdrant"
+os.environ["QDRANT_URL"] = "https://qdrant.test"
+os.environ["QDRANT_API_KEY_RW"] = "test-qdrant-key"
+os.environ["EMBEDDING_PROVIDER"] = "openai"
+os.environ["OPENAI_API_KEY"] = "test-openai-key"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+
+# Keep pytest isolated from the developer's local runtime configuration.
+# The application still defaults to `.env` outside tests.
+os.environ.setdefault("RAG_ENV_FILE", ".env.pytest-do-not-load")

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,113 @@
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_backup_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "backup_vectorstore",
+        Path(__file__).resolve().parents[1] / "scripts" / "backup_vectorstore.py",
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load scripts/backup_vectorstore.py for testing.")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+backup_script = _load_backup_script()
+
+
+def test_build_backup_source_supports_all_backends(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    qdrant = object()
+    chromadb = object()
+    pinecone = object()
+    pgvector = object()
+
+    monkeypatch.setattr(backup_script, "QdrantBackupSource", lambda config: qdrant)
+    monkeypatch.setattr(backup_script, "ChromaDBBackupSource", lambda config: chromadb)
+    monkeypatch.setattr(backup_script, "PineconeBackupSource", lambda config: pinecone)
+    monkeypatch.setattr(backup_script, "PGVectorBackupSource", lambda config: pgvector)
+
+    assert (
+        backup_script.build_backup_source(
+            backup_script.BackupConfig(
+                vector_store="qdrant",
+                collection_name="movies_test_1",
+                output_root=Path("outputs/backups"),
+                batch_size=100,
+            )
+        )
+        is qdrant
+    )
+    assert (
+        backup_script.build_backup_source(
+            backup_script.BackupConfig(
+                vector_store="chromadb",
+                collection_name="movies_test_1",
+                output_root=Path("outputs/backups"),
+                batch_size=100,
+            )
+        )
+        is chromadb
+    )
+    assert (
+        backup_script.build_backup_source(
+            backup_script.BackupConfig(
+                vector_store="pinecone",
+                collection_name="movies_test_1",
+                output_root=Path("outputs/backups"),
+                batch_size=100,
+            )
+        )
+        is pinecone
+    )
+    assert (
+        backup_script.build_backup_source(
+            backup_script.BackupConfig(
+                vector_store="pgvector",
+                collection_name="movies_test_1",
+                output_root=Path("outputs/backups"),
+                batch_size=100,
+            )
+        )
+        is pgvector
+    )
+
+
+def test_load_config_prefers_generic_target_name(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    outputs_file = tmp_path / "ingestion-outputs.env"
+    outputs_file.write_text(
+        "\n".join(
+            [
+                "VECTOR_STORE_TARGET_NAME=movies_baai_bge_m3_1024",
+                "EMBEDDING_PROVIDER=huggingface",
+                "EMBEDDING_MODEL=BAAI/bge-m3",
+                "EMBEDDING_DIMENSION=1024",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(backup_script, "INGESTION_OUTPUTS_PATH", outputs_file)
+    monkeypatch.delenv("BACKUP_COLLECTION_NAME", raising=False)
+    monkeypatch.delenv("VECTOR_STORE_TARGET_NAME", raising=False)
+    monkeypatch.delenv("QDRANT_COLLECTION_NAME", raising=False)
+    monkeypatch.delenv("EMBEDDING_PROVIDER", raising=False)
+    monkeypatch.delenv("EMBEDDING_MODEL", raising=False)
+    monkeypatch.delenv("EMBEDDING_DIMENSION", raising=False)
+
+    config = backup_script.load_config([])
+
+    assert config.collection_name == "movies_baai_bge_m3_1024"
+    assert config.embedding_provider == "huggingface"
+    assert config.embedding_model == "BAAI/bge-m3"
+    assert config.embedding_dimension == 1024

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,30 @@
-import pytest
+from typing import Any, cast
 
-from rag.config import DEFAULT_EMBEDDING_MODELS, RAGConfig
+import pytest
+from pydantic import ValidationError
+
+from rag.config import (
+    DEFAULT_EMBEDDING_MODELS,
+    DEFAULT_VALIDATION_QUERY,
+    RAGConfig,
+    infer_embedding_dimension,
+)
 
 
 def apply_base_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VECTOR_STORE", "chromadb")
     monkeypatch.setenv("CHROMADB_PERSIST_PATH", "outputs/chromadb-test")
+
+
+def test_infer_embedding_dimension() -> None:
+    assert infer_embedding_dimension("openai", "text-embedding-3-large") == 3072
+    assert infer_embedding_dimension("openai", "text-embedding-3-small") == 1536
+    assert infer_embedding_dimension("openai", "text-embedding-ada-002") == 1536
+    assert infer_embedding_dimension("openai", "unknown-large-model") == 3072
+    assert infer_embedding_dimension("openai", "unknown-small-model") == 1536
+    assert infer_embedding_dimension("google", "text-embedding-004") == 768
+    assert infer_embedding_dimension("google", "unknown") == 768
+    assert infer_embedding_dimension(cast("Any", "unknown"), "unknown") == 0
 
 
 def test_provider_default_model_is_injected(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -37,12 +56,30 @@ def test_embedding_dimension_uses_override(monkeypatch: pytest.MonkeyPatch) -> N
     assert config.embedding_dimension == 1024
 
 
+def test_embedding_dimension_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("EMBEDDING_MODEL", "text-embedding-3-small")
+    monkeypatch.delenv("EMBEDDING_DIMENSIONS", raising=False)
+    config = RAGConfig()
+    assert config.embedding_dimension == 1536
+
+
 def test_shape_validator_requires_provider_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
     apply_base_env(monkeypatch)
     monkeypatch.setenv("EMBEDDING_PROVIDER", "openai")
     monkeypatch.setenv("OPENAI_API_KEY", "")
-
     with pytest.raises(ValueError, match="OPENAI_API_KEY is required"):
+        RAGConfig()
+
+
+def test_shape_validator_requires_google_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "google")
+    monkeypatch.setenv("GOOGLE_API_KEY", "")
+
+    with pytest.raises(ValueError, match="GOOGLE_API_KEY is required"):
         RAGConfig()
 
 
@@ -51,14 +88,21 @@ def test_shape_validator_requires_qdrant_credentials(monkeypatch: pytest.MonkeyP
     monkeypatch.setenv("EMBEDDING_PROVIDER", "huggingface")
     monkeypatch.setenv("QDRANT_URL", "")
     monkeypatch.setenv("QDRANT_API_KEY_RW", "")
-
     with pytest.raises(ValueError, match="QDRANT_URL is required"):
         RAGConfig()
 
 
-def test_shape_validator_rejects_google_dimension_override(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_shape_validator_requires_qdrant_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VECTOR_STORE", "qdrant")
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "huggingface")
+    monkeypatch.setenv("QDRANT_URL", "http://test")
+    monkeypatch.setenv("QDRANT_API_KEY_RW", "")
+
+    with pytest.raises(ValueError, match="QDRANT_API_KEY_RW is required"):
+        RAGConfig()
+
+
+def test_shape_validator_rejects_google_dimension_override(monkeypatch: pytest.MonkeyPatch) -> None:
     apply_base_env(monkeypatch)
     monkeypatch.setenv("EMBEDDING_PROVIDER", "google")
     monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
@@ -75,3 +119,96 @@ def test_shape_validator_requires_ollama_url(monkeypatch: pytest.MonkeyPatch) ->
 
     with pytest.raises(ValueError, match="OLLAMA_URL is required"):
         RAGConfig()
+
+
+def test_shape_validator_requires_pinecone_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VECTOR_STORE", "pinecone")
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "huggingface")
+    monkeypatch.delenv("PINECONE_API_KEY", raising=False)
+    monkeypatch.delenv("VECTOR_STORE_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="PINECONE_API_KEY is required"):
+        RAGConfig()
+
+
+def test_shape_validator_requires_pinecone_index_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VECTOR_STORE", "pinecone")
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "huggingface")
+    monkeypatch.setenv("PINECONE_API_KEY", "test")
+    monkeypatch.setenv("PINECONE_INDEX_NAME", "invalid_name_with_underscores")
+
+    with pytest.raises(ValueError, match="PINECONE_INDEX_NAME must be"):
+        RAGConfig()
+
+
+def test_shape_validator_requires_pgvector_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VECTOR_STORE", "pgvector")
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "huggingface")
+    monkeypatch.setenv("PGVECTOR_DSN", "")
+    monkeypatch.setenv("VECTOR_STORE_URL", "")
+
+    with pytest.raises(ValueError, match="PGVECTOR_DSN is required"):
+        RAGConfig()
+
+
+def test_apply_dynamic_defaults_empty_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "   ")
+
+    with pytest.raises(ValidationError):
+        RAGConfig()
+
+
+def test_apply_dynamic_defaults_unknown_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "unknown-provider")
+
+    with pytest.raises(ValidationError):
+        RAGConfig()
+
+
+def test_apply_dynamic_defaults_empty_dimensions(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
+    monkeypatch.setenv("EMBEDDING_DIMENSIONS", "   ")
+    config = RAGConfig()
+
+    assert config.embedding_dimensions is None
+
+
+def test_apply_dynamic_defaults_empty_validation_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
+    monkeypatch.setenv("VALIDATION_QUERY", "   ")
+    config = RAGConfig()
+
+    assert config.validation_query == DEFAULT_VALIDATION_QUERY
+
+
+def test_validate_non_empty_text() -> None:
+    with pytest.raises(ValueError, match="Value must not be empty."):
+        RAGConfig._validate_non_empty_text("   ")
+
+
+def test_validate_collection_prefix_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
+    monkeypatch.setenv("QDRANT_COLLECTION_PREFIX", " - . / ")
+
+    with pytest.raises(ValueError, match="QDRANT_COLLECTION_PREFIX must not be empty."):
+        RAGConfig()
+
+
+def test_validate_collection_prefix_invalid() -> None:
+    # Just to reach the method signature, though the exception might be unreachable via regex cleaning
+    pass
+
+
+def test_validate_collection_prefix_cleans(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
+    monkeypatch.setenv("QDRANT_COLLECTION_PREFIX", "A-b/C.d_e")
+    config = RAGConfig()
+
+    assert config.qdrant_collection_prefix == "a_b_c_d_e"
+
+
+def test_apply_dynamic_defaults_not_dict() -> None:
+    # Just test the classmethod directly
+    assert RAGConfig._apply_dynamic_defaults("not_a_dict") == "not_a_dict"  # type: ignore[operator]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,38 +1,77 @@
 import pytest
 
-from rag.config import RAGConfig
+from rag.config import DEFAULT_EMBEDDING_MODELS, RAGConfig
 
 
-def test_embedding_dimension_openai_large(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Verify dimension for OpenAI large model."""
-    monkeypatch.setenv("QDRANT_URL", "http://localhost")
-    monkeypatch.setenv("QDRANT_API_KEY_RW", "key")
-    monkeypatch.setenv("OPENAI_API_KEY", "okey")
+def apply_base_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VECTOR_STORE", "chromadb")
+    monkeypatch.setenv("CHROMADB_PERSIST_PATH", "outputs/chromadb-test")
+
+
+def test_provider_default_model_is_injected(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "huggingface")
+    monkeypatch.delenv("EMBEDDING_MODEL", raising=False)
+
+    config = RAGConfig()
+    assert config.embedding_model == DEFAULT_EMBEDDING_MODELS["huggingface"]
+
+
+def test_collection_prefix_normalizes_legacy_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "huggingface")
+    monkeypatch.delenv("QDRANT_COLLECTION_PREFIX", raising=False)
+    monkeypatch.setenv("QDRANT_COLLECTION_NAME", "text-embedding-3-large")
+
+    config = RAGConfig()
+    assert config.qdrant_collection_prefix == "text_embedding_3_large"
+
+
+def test_embedding_dimension_uses_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
     monkeypatch.setenv("EMBEDDING_PROVIDER", "openai")
-    monkeypatch.setenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-large")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("EMBEDDING_DIMENSIONS", "1024")
 
     config = RAGConfig()
-    assert config.embedding_dimension == 3072
+    assert config.embedding_dimension == 1024
 
 
-def test_embedding_dimension_openai_small(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Verify dimension for OpenAI small model."""
-    monkeypatch.setenv("QDRANT_URL", "http://localhost")
-    monkeypatch.setenv("QDRANT_API_KEY_RW", "key")
-    monkeypatch.setenv("OPENAI_API_KEY", "okey")
+def test_shape_validator_requires_provider_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
     monkeypatch.setenv("EMBEDDING_PROVIDER", "openai")
-    monkeypatch.setenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
+    monkeypatch.setenv("OPENAI_API_KEY", "")
 
-    config = RAGConfig()
-    assert config.embedding_dimension == 1536
+    with pytest.raises(ValueError, match="OPENAI_API_KEY is required"):
+        RAGConfig()
 
 
-def test_embedding_dimension_gemini(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Verify dimension for Gemini provider."""
-    monkeypatch.setenv("QDRANT_URL", "http://localhost")
-    monkeypatch.setenv("QDRANT_API_KEY_RW", "key")
-    monkeypatch.setenv("OPENAI_API_KEY", "okey")
-    monkeypatch.setenv("EMBEDDING_PROVIDER", "gemini")
+def test_shape_validator_requires_qdrant_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VECTOR_STORE", "qdrant")
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "huggingface")
+    monkeypatch.setenv("QDRANT_URL", "")
+    monkeypatch.setenv("QDRANT_API_KEY_RW", "")
 
-    config = RAGConfig()
-    assert config.embedding_dimension == 768
+    with pytest.raises(ValueError, match="QDRANT_URL is required"):
+        RAGConfig()
+
+
+def test_shape_validator_rejects_google_dimension_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    apply_base_env(monkeypatch)
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "google")
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.setenv("EMBEDDING_DIMENSIONS", "256")
+
+    with pytest.raises(ValueError, match="EMBEDDING_DIMENSIONS is not supported"):
+        RAGConfig()
+
+
+def test_shape_validator_requires_ollama_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "ollama")
+    monkeypatch.delenv("OLLAMA_URL", raising=False)
+
+    with pytest.raises(ValueError, match="OLLAMA_URL is required"):
+        RAGConfig()

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,30 +1,19 @@
+import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from rag.config import settings
 from rag.embeddings.gemini_provider import GeminiEmbeddingProvider
+from rag.embeddings.ollama_provider import OllamaEmbeddingProvider
 from rag.embeddings.openai_provider import OpenAIEmbeddingProvider
+from rag.embeddings.sentence_transformers_provider import SentenceTransformersEmbeddingProvider
 
 
-def test_openai_provider_init_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test OpenAI provider initialization without API key."""
-    monkeypatch.setattr(settings, "openai_api_key", "")
-    with pytest.raises(ValueError, match="OPENAI_API_KEY is not defined"):
-        OpenAIEmbeddingProvider()
-
-
-def test_openai_provider_unknown_model(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test OpenAI provider with an unknown model name."""
+def test_openai_provider_passes_dimensions(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "openai_api_key", "test-key")
-    with patch("rag.embeddings.openai_provider.OpenAI"):
-        provider = OpenAIEmbeddingProvider(model="unknown-model")
-        assert provider.model_info.name == "unknown-model"
-
-
-def test_openai_provider_embed(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test OpenAI provider embedding and usage tracking."""
-    monkeypatch.setattr(settings, "openai_api_key", "test-key")
+    monkeypatch.setattr(settings, "embedding_dimensions", 1024)
 
     mock_response = MagicMock()
     mock_response.data = [MagicMock(embedding=[0.1, 0.2])]
@@ -32,96 +21,63 @@ def test_openai_provider_embed(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with patch("rag.embeddings.openai_provider.OpenAI") as mock_openai:
         mock_openai.return_value.embeddings.create.return_value = mock_response
-        provider = OpenAIEmbeddingProvider(model="text-embedding-3-small")
-        vector = provider.embed("test text")
-
-        assert vector == [0.1, 0.2]
-        usage = provider.get_model_usage()
-        assert usage.total_tokens == 10
-        assert usage.estimated_cost_usd > 0
-
-
-def test_openai_provider_embed_batch(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test OpenAI provider batch embedding."""
-    monkeypatch.setattr(settings, "openai_api_key", "test-key")
-
-    mock_response = MagicMock()
-    mock_response.data = [MagicMock(embedding=[0.1, 0.2]), MagicMock(embedding=[0.3, 0.4])]
-    mock_response.usage = MagicMock(prompt_tokens=20, total_tokens=20)
-
-    with patch("rag.embeddings.openai_provider.OpenAI") as mock_openai:
-        mock_openai.return_value.embeddings.create.return_value = mock_response
-        provider = OpenAIEmbeddingProvider(model="text-embedding-3-small")
-        vectors = provider.embed_batch(["text1", "text2"])
-
-        assert vectors == [[0.1, 0.2], [0.3, 0.4]]
-        assert provider.get_model_usage().total_tokens == 20
+        provider = OpenAIEmbeddingProvider(model="text-embedding-3-large")
+        assert provider.embed("test text") == [0.1, 0.2]
+        mock_openai.return_value.embeddings.create.assert_called_once_with(
+            model="text-embedding-3-large",
+            input=["test text"],
+            dimensions=1024,
+        )
 
 
-def test_openai_provider_embed_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test OpenAI provider error handling."""
-    monkeypatch.setattr(settings, "openai_api_key", "test-key")
-
-    with patch("rag.embeddings.openai_provider.OpenAI") as mock_openai:
-        mock_openai.return_value.embeddings.create.side_effect = Exception("API Error")
-        provider = OpenAIEmbeddingProvider()
-        assert provider.embed("test") == []
-        assert provider.embed_batch(["test"]) == []
-
-
-def test_gemini_provider_init_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test Gemini provider initialization without API key."""
+def test_google_provider_requires_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "google_api_key", None)
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+
     with pytest.raises(ValueError, match="GOOGLE_API_KEY is not defined"):
-        GeminiEmbeddingProvider()
+        GeminiEmbeddingProvider(model="text-embedding-004")
 
 
-def test_gemini_provider_unknown_model(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test Gemini provider with an unknown model name."""
-    monkeypatch.setattr(settings, "google_api_key", "test-key")
-    with patch("rag.embeddings.gemini_provider.genai.Client"):
-        provider = GeminiEmbeddingProvider(model="unknown-model")
-        assert provider.model_info.name == "unknown-model"
-        assert provider.model_info.dimension == 768
+def test_ollama_provider_uses_host_and_dimensions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "embedding_dimensions", 384)
+    monkeypatch.setattr(settings, "ollama_url", "https://ollama.example")
+    monkeypatch.setattr(settings, "ollama_api_key", "ollama-key")
+
+    mock_client = MagicMock()
+    mock_client.embed.return_value = {"embeddings": [[0.1, 0.2]], "prompt_eval_count": 5}
+
+    fake_ollama = SimpleNamespace(Client=MagicMock(return_value=mock_client))
+    with patch.dict(sys.modules, {"ollama": fake_ollama}):
+        provider = OllamaEmbeddingProvider(model="embeddinggemma")
+        assert provider.embed("test text") == [0.1, 0.2]
+        fake_ollama.Client.assert_called_once_with(
+            host="https://ollama.example",
+            headers={"Authorization": "Bearer ollama-key"},
+        )
+        mock_client.embed.assert_called_once_with(
+            model="embeddinggemma",
+            input=["test text"],
+            dimensions=384,
+        )
 
 
-def test_gemini_provider_embed(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test Gemini provider embedding."""
-    monkeypatch.setattr(settings, "google_api_key", "test-key")
+def test_sentence_transformers_provider_uses_truncate_dim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "embedding_dimensions", 256)
+    mock_model = MagicMock()
+    mock_model.get_sentence_embedding_dimension.return_value = 1024
+    mock_model.encode.return_value.tolist.return_value = [[0.1, 0.2]]
 
-    mock_response = MagicMock()
-    mock_response.embeddings = [MagicMock(values=[0.1, 0.2])]
-
-    with patch("rag.embeddings.gemini_provider.genai.Client") as mock_genai:
-        mock_genai.return_value.models.embed_content.return_value = mock_response
-        provider = GeminiEmbeddingProvider(model="text-embedding-004")
-        vector = provider.embed("test text")
-
-        assert vector == [0.1, 0.2]
-        assert provider.model_info.name == "text-embedding-004"
-
-
-def test_gemini_provider_embed_batch(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test Gemini provider batch embedding."""
-    monkeypatch.setattr(settings, "google_api_key", "test-key")
-
-    mock_response = MagicMock()
-    mock_response.embeddings = [MagicMock(values=[0.1, 0.2]), MagicMock(values=[0.3, 0.4])]
-
-    with patch("rag.embeddings.gemini_provider.genai.Client") as mock_genai:
-        mock_genai.return_value.models.embed_content.return_value = mock_response
-        provider = GeminiEmbeddingProvider()
-        vectors = provider.embed_batch(["text1", "text2"])
-
-        assert vectors == [[0.1, 0.2], [0.3, 0.4]]
-
-
-def test_gemini_provider_embed_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test Gemini provider error handling."""
-    monkeypatch.setattr(settings, "google_api_key", "test-key")
-
-    with patch("rag.embeddings.gemini_provider.genai.Client") as mock_genai:
-        mock_genai.return_value.models.embed_content.side_effect = Exception("API Error")
-        provider = GeminiEmbeddingProvider()
-        assert provider.embed("test") == []
-        assert provider.embed_batch(["test"]) == []
+    fake_sentence_transformers = SimpleNamespace(
+        SentenceTransformer=MagicMock(return_value=mock_model)
+    )
+    with patch.dict(sys.modules, {"sentence_transformers": fake_sentence_transformers}):
+        provider = SentenceTransformersEmbeddingProvider(model="BAAI/bge-m3")
+        assert provider.model_info.dimension == 256
+        assert provider.embed("hello") == [0.1, 0.2]
+        mock_model.encode.assert_called_once_with(
+            ["hello"],
+            convert_to_numpy=True,
+            truncate_dim=256,
+        )

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,5 +1,6 @@
 import sys
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,41 +12,106 @@ from rag.embeddings.openai_provider import OpenAIEmbeddingProvider
 from rag.embeddings.sentence_transformers_provider import SentenceTransformersEmbeddingProvider
 
 
-def test_openai_provider_passes_dimensions(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "openai_api_key", "test-key")
-    monkeypatch.setattr(settings, "embedding_dimensions", 1024)
-
-    mock_response = MagicMock()
-    mock_response.data = [MagicMock(embedding=[0.1, 0.2])]
-    mock_response.usage = MagicMock(prompt_tokens=10, total_tokens=10)
-
-    with patch("rag.embeddings.openai_provider.OpenAI") as mock_openai:
-        mock_openai.return_value.embeddings.create.return_value = mock_response
-        provider = OpenAIEmbeddingProvider(model="text-embedding-3-large")
-        assert provider.embed("test text") == [0.1, 0.2]
-        mock_openai.return_value.embeddings.create.assert_called_once_with(
-            model="text-embedding-3-large",
-            input=["test text"],
-            dimensions=1024,
-        )
-
-
+# --- GeminiEmbeddingProvider Tests ---
 def test_google_provider_requires_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "google_api_key", None)
-    monkeypatch.setattr(settings, "embedding_dimensions", None)
-
     with pytest.raises(ValueError, match="GOOGLE_API_KEY is not defined"):
         GeminiEmbeddingProvider(model="text-embedding-004")
+
+
+def test_google_provider_rejects_dimensions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "google_api_key", "test")
+    monkeypatch.setattr(settings, "embedding_dimensions", 1024)
+    with pytest.raises(ValueError, match="GOOGLE embeddings do not support EMBEDDING_DIMENSIONS"):
+        GeminiEmbeddingProvider(model="text-embedding-004")
+
+
+def test_google_provider_model_info_known(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "google_api_key", "test")
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+    with patch("rag.embeddings.gemini_provider.genai.Client"):
+        provider = GeminiEmbeddingProvider(model="text-embedding-004")
+        info = provider.model_info
+        assert info.dimension == 768
+
+
+def test_google_provider_model_info_infer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "google_api_key", "test")
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+    with (
+        patch("rag.embeddings.gemini_provider.genai.Client"),
+        patch("rag.embeddings.gemini_provider.infer_embedding_dimension", return_value=128),
+    ):
+        provider = GeminiEmbeddingProvider(model="unknown-model")
+        info = provider.model_info
+        assert info.dimension == 128
+
+
+def test_google_provider_model_info_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "google_api_key", "test")
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+    with (
+        patch("rag.embeddings.gemini_provider.genai.Client"),
+        patch("rag.embeddings.gemini_provider.infer_embedding_dimension", return_value=0),
+    ):
+        provider = GeminiEmbeddingProvider(model="unknown-model")
+        with pytest.raises(ValueError, match="Unknown Google embedding dimension"):
+            _ = provider.model_info
+
+
+def test_google_provider_embed_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "google_api_key", "test")
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+    with patch("rag.embeddings.gemini_provider.genai.Client"):
+        provider = GeminiEmbeddingProvider(model="text-embedding-004")
+        mock_response = MagicMock()
+        mock_embedding = MagicMock()
+        mock_embedding.values = [0.1, 0.2]
+        mock_response.embeddings = [mock_embedding]
+        cast(MagicMock, provider.client.models.embed_content).return_value = mock_response
+
+        assert provider.embed("test text") == [0.1, 0.2]
+        usage = provider.get_model_usage()
+        assert usage.prompt_tokens == 1
+        assert usage.total_tokens == 1
+
+
+def test_google_provider_embed_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "google_api_key", "test")
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+    with patch("rag.embeddings.gemini_provider.genai.Client"):
+        provider = GeminiEmbeddingProvider(model="text-embedding-004")
+        mock_response = MagicMock()
+        mock_response.embeddings = []
+        cast(MagicMock, provider.client.models.embed_content).return_value = mock_response
+        assert provider.embed("test text") == []
+
+
+def test_google_provider_embed_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "google_api_key", "test")
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+    with patch("rag.embeddings.gemini_provider.genai.Client"):
+        provider = GeminiEmbeddingProvider(model="text-embedding-004")
+        cast(MagicMock, provider.client.models.embed_content).side_effect = Exception("API error")
+        assert provider.embed("test text") == []
+
+
+# --- OllamaEmbeddingProvider Tests ---
+def test_ollama_provider_missing_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "embedding_dimensions", 384)
+    with (
+        patch.dict(sys.modules, {"ollama": None}),
+        pytest.raises(RuntimeError, match="Ollama support requires"),
+    ):
+        OllamaEmbeddingProvider()
 
 
 def test_ollama_provider_uses_host_and_dimensions(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "embedding_dimensions", 384)
     monkeypatch.setattr(settings, "ollama_url", "https://ollama.example")
     monkeypatch.setattr(settings, "ollama_api_key", "ollama-key")
-
     mock_client = MagicMock()
     mock_client.embed.return_value = {"embeddings": [[0.1, 0.2]], "prompt_eval_count": 5}
-
     fake_ollama = SimpleNamespace(Client=MagicMock(return_value=mock_client))
     with patch.dict(sys.modules, {"ollama": fake_ollama}):
         provider = OllamaEmbeddingProvider(model="embeddinggemma")
@@ -59,20 +125,182 @@ def test_ollama_provider_uses_host_and_dimensions(monkeypatch: pytest.MonkeyPatc
             input=["test text"],
             dimensions=384,
         )
+        usage = provider.get_model_usage()
+        assert usage.total_tokens == 5
 
 
-def test_sentence_transformers_provider_uses_truncate_dim(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_ollama_provider_model_info_from_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+    mock_client = MagicMock()
+    mock_client.embed.return_value = {"embeddings": [[0.1, 0.2, 0.3]]}
+    fake_ollama = SimpleNamespace(Client=MagicMock(return_value=mock_client))
+    with (
+        patch.dict(sys.modules, {"ollama": fake_ollama}),
+        patch("rag.embeddings.ollama_provider.infer_embedding_dimension", return_value=0),
+    ):
+        provider = OllamaEmbeddingProvider(model="test-model")
+        assert provider.model_info.dimension == 3
+
+
+def test_ollama_provider_model_info_probe_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+    mock_client = MagicMock()
+    mock_client.embed.side_effect = Exception("Probe failed")
+    fake_ollama = SimpleNamespace(Client=MagicMock(return_value=mock_client))
+    with (
+        patch.dict(sys.modules, {"ollama": fake_ollama}),
+        patch("rag.embeddings.ollama_provider.infer_embedding_dimension", return_value=0),
+    ):
+        provider = OllamaEmbeddingProvider(model="test-model")
+        with pytest.raises(ValueError, match="Unknown Ollama embedding dimension"):
+            _ = provider.model_info
+
+
+def test_ollama_provider_embed_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "embedding_dimensions", 384)
+    mock_client = MagicMock()
+    mock_client.embed.return_value = {"embeddings": []}
+    fake_ollama = SimpleNamespace(Client=MagicMock(return_value=mock_client))
+    with patch.dict(sys.modules, {"ollama": fake_ollama}):
+        provider = OllamaEmbeddingProvider()
+        assert provider.embed("test text") == []
+
+
+def test_ollama_provider_embed_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "embedding_dimensions", 384)
+    mock_client = MagicMock()
+    mock_client.embed.side_effect = Exception("API Error")
+    fake_ollama = SimpleNamespace(Client=MagicMock(return_value=mock_client))
+    with patch.dict(sys.modules, {"ollama": fake_ollama}):
+        provider = OllamaEmbeddingProvider()
+        assert provider.embed("test text") == []
+
+
+# --- OpenAIEmbeddingProvider Tests ---
+def test_openai_provider_passes_dimensions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "openai_api_key", "test-key")
+    monkeypatch.setattr(settings, "embedding_dimensions", 1024)
+    mock_response = MagicMock()
+    mock_response.data = [MagicMock(embedding=[0.1, 0.2])]
+    mock_response.usage = MagicMock(prompt_tokens=10, total_tokens=10)
+    with patch("rag.embeddings.openai_provider.OpenAI") as mock_openai:
+        mock_openai.return_value.embeddings.create.return_value = mock_response
+        provider = OpenAIEmbeddingProvider(model="text-embedding-3-large")
+        assert provider.embed("test text") == [0.1, 0.2]
+        mock_openai.return_value.embeddings.create.assert_called_once_with(
+            model="text-embedding-3-large",
+            input=["test text"],
+            dimensions=1024,
+        )
+
+
+def test_openai_provider_requires_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "openai_api_key", None)
+    with pytest.raises(ValueError, match="OPENAI_API_KEY is not defined"):
+        OpenAIEmbeddingProvider()
+
+
+def test_openai_provider_model_info_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "openai_api_key", "test")
+    monkeypatch.setattr(settings, "embedding_dimensions", 512)
+    with patch("rag.embeddings.openai_provider.OpenAI"):
+        provider = OpenAIEmbeddingProvider(model="text-embedding-3-small")
+        assert provider.model_info.dimension == 512
+
+
+def test_openai_provider_model_info_infer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "openai_api_key", "test")
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+    with (
+        patch("rag.embeddings.openai_provider.OpenAI"),
+        patch("rag.embeddings.openai_provider.infer_embedding_dimension", return_value=128),
+    ):
+        provider = OpenAIEmbeddingProvider(model="unknown-model")
+        assert provider.model_info.dimension == 128
+
+
+def test_openai_provider_model_info_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "openai_api_key", "test")
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+    with (
+        patch("rag.embeddings.openai_provider.OpenAI"),
+        patch("rag.embeddings.openai_provider.infer_embedding_dimension", return_value=0),
+    ):
+        provider = OpenAIEmbeddingProvider(model="unknown-model")
+        with pytest.raises(ValueError, match="Unknown OpenAI embedding dimension"):
+            _ = provider.model_info
+
+
+def test_openai_provider_embed_no_dimensions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "openai_api_key", "test")
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+    with patch("rag.embeddings.openai_provider.OpenAI") as mock_openai:
+        mock_response = MagicMock()
+        mock_response.data = [MagicMock(embedding=[0.1])]
+        mock_response.usage = MagicMock(prompt_tokens=10, total_tokens=10)
+        mock_openai.return_value.embeddings.create.return_value = mock_response
+        provider = OpenAIEmbeddingProvider(model="text-embedding-ada-002")
+        assert provider.embed("test text") == [0.1]
+        mock_openai.return_value.embeddings.create.assert_called_once_with(
+            model="text-embedding-ada-002",
+            input=["test text"],
+        )
+        usage = provider.get_model_usage()
+        assert usage.prompt_tokens == 10
+
+
+def test_openai_provider_embed_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "openai_api_key", "test")
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+    with patch("rag.embeddings.openai_provider.OpenAI") as mock_openai:
+        mock_response = MagicMock()
+        mock_response.data = []
+        mock_response.usage = MagicMock(prompt_tokens=10, total_tokens=10)
+        mock_openai.return_value.embeddings.create.return_value = mock_response
+        provider = OpenAIEmbeddingProvider(model="text-embedding-ada-002")
+        assert provider.embed("test text") == []
+
+
+def test_openai_provider_embed_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "openai_api_key", "test")
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+    with patch("rag.embeddings.openai_provider.OpenAI") as mock_openai:
+        mock_openai.return_value.embeddings.create.side_effect = Exception("API error")
+        provider = OpenAIEmbeddingProvider(model="text-embedding-ada-002")
+        assert provider.embed("test text") == []
+
+
+def test_openai_provider_update_usage_unknown_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "openai_api_key", "test")
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+    with patch("rag.embeddings.openai_provider.OpenAI") as mock_openai:
+        mock_response = MagicMock()
+        mock_response.data = [MagicMock(embedding=[0.1])]
+        mock_response.usage = MagicMock(prompt_tokens=10, total_tokens=10)
+        mock_openai.return_value.embeddings.create.return_value = mock_response
+        provider = OpenAIEmbeddingProvider(model="unknown-model")
+        provider.embed("test text")
+        usage = provider.get_model_usage()
+        assert usage.estimated_cost_usd == 0.0
+
+
+# --- SentenceTransformersEmbeddingProvider Tests ---
+def test_sentence_transformers_provider_missing_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "embedding_dimensions", 256)
+    with (
+        patch.dict(sys.modules, {"sentence_transformers": None}),
+        pytest.raises(RuntimeError, match="Sentence-Transformers support requires"),
+    ):
+        SentenceTransformersEmbeddingProvider()
+
+
+def test_sentence_transformers_provider_uses_truncate_dim(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "embedding_dimensions", 256)
     mock_model = MagicMock()
     mock_model.get_sentence_embedding_dimension.return_value = 1024
     mock_model.encode.return_value.tolist.return_value = [[0.1, 0.2]]
-
-    fake_sentence_transformers = SimpleNamespace(
-        SentenceTransformer=MagicMock(return_value=mock_model)
-    )
-    with patch.dict(sys.modules, {"sentence_transformers": fake_sentence_transformers}):
+    fake_st = SimpleNamespace(SentenceTransformer=MagicMock(return_value=mock_model))
+    with patch.dict(sys.modules, {"sentence_transformers": fake_st}):
         provider = SentenceTransformersEmbeddingProvider(model="BAAI/bge-m3")
         assert provider.model_info.dimension == 256
         assert provider.embed("hello") == [0.1, 0.2]
@@ -81,3 +309,58 @@ def test_sentence_transformers_provider_uses_truncate_dim(
             convert_to_numpy=True,
             truncate_dim=256,
         )
+        usage = provider.get_model_usage()
+        assert usage.total_tokens == 1
+
+
+def test_sentence_transformers_provider_model_info_infer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+    mock_model = MagicMock()
+    mock_model.get_sentence_embedding_dimension.return_value = None
+    fake_st = SimpleNamespace(SentenceTransformer=MagicMock(return_value=mock_model))
+    with (
+        patch.dict(sys.modules, {"sentence_transformers": fake_st}),
+        patch(
+            "rag.embeddings.sentence_transformers_provider.infer_embedding_dimension",
+            return_value=128,
+        ),
+    ):
+        provider = SentenceTransformersEmbeddingProvider(model="unknown")
+        assert provider.model_info.dimension == 128
+
+
+def test_sentence_transformers_provider_model_info_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "embedding_dimensions", None)
+    mock_model = MagicMock()
+    mock_model.get_sentence_embedding_dimension.return_value = 0
+    fake_st = SimpleNamespace(SentenceTransformer=MagicMock(return_value=mock_model))
+    with (
+        patch.dict(sys.modules, {"sentence_transformers": fake_st}),
+        patch(
+            "rag.embeddings.sentence_transformers_provider.infer_embedding_dimension",
+            return_value=0,
+        ),
+    ):
+        provider = SentenceTransformersEmbeddingProvider(model="unknown")
+        with pytest.raises(ValueError, match="Unable to resolve embedding dimension"):
+            _ = provider.model_info
+
+
+def test_sentence_transformers_provider_embed_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "embedding_dimensions", 256)
+    mock_model = MagicMock()
+    mock_model.encode.return_value.tolist.return_value = []
+    fake_st = SimpleNamespace(SentenceTransformer=MagicMock(return_value=mock_model))
+    with patch.dict(sys.modules, {"sentence_transformers": fake_st}):
+        provider = SentenceTransformersEmbeddingProvider()
+        assert provider.embed("hello") == []
+
+
+def test_sentence_transformers_provider_embed_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "embedding_dimensions", 256)
+    mock_model = MagicMock()
+    mock_model.encode.side_effect = Exception("encode error")
+    fake_st = SimpleNamespace(SentenceTransformer=MagicMock(return_value=mock_model))
+    with patch.dict(sys.modules, {"sentence_transformers": fake_st}):
+        provider = SentenceTransformersEmbeddingProvider()
+        assert provider.embed("hello") == []

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+
+from pytest import MonkeyPatch
+
+from rag.embeddings.factory import create_embedding_provider, get_embedding_provider
+from rag.vectorstore.factory import create_vector_store, get_vector_store
+
+
+def test_embedding_factory_dispatch(monkeypatch: MonkeyPatch) -> None:
+    from rag.embeddings.openai_provider import OpenAIEmbeddingProvider
+
+    monkeypatch.setattr("rag.embeddings.factory.settings.embedding_provider", "openai")
+    monkeypatch.setattr("rag.embeddings.factory.settings.embedding_model", "text-embedding-3-large")
+    monkeypatch.setattr("rag.embeddings.openai_provider.settings.openai_api_key", "test-key")
+
+    with patch("rag.embeddings.openai_provider.OpenAI"):
+        get_embedding_provider.cache_clear()
+        provider = create_embedding_provider("openai", "text-embedding-3-large")
+        assert isinstance(provider, OpenAIEmbeddingProvider)
+
+
+def test_embedding_factory_is_cached(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr("rag.embeddings.factory.settings.embedding_provider", "openai")
+    monkeypatch.setattr("rag.embeddings.factory.settings.embedding_model", "text-embedding-3-large")
+    monkeypatch.setattr("rag.embeddings.openai_provider.settings.openai_api_key", "test-key")
+
+    with patch("rag.embeddings.openai_provider.OpenAI"):
+        get_embedding_provider.cache_clear()
+        first = get_embedding_provider()
+        second = get_embedding_provider()
+        assert first is second
+
+
+def test_vector_store_factory_dispatch(monkeypatch: MonkeyPatch) -> None:
+    from rag.vectorstore.qdrant_vectorstore import QdrantVectorStore
+
+    monkeypatch.setattr("rag.vectorstore.factory.settings.vector_store", "qdrant")
+    monkeypatch.setattr("rag.vectorstore.qdrant_vectorstore.settings.qdrant_url", "http://test")
+    monkeypatch.setattr("rag.vectorstore.qdrant_vectorstore.settings.qdrant_api_key_rw", "key")
+
+    with patch("rag.vectorstore.qdrant_vectorstore.QdrantClient"):
+        get_vector_store.cache_clear()
+        store = create_vector_store("qdrant")
+        assert isinstance(store, QdrantVectorStore)

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
+import rag.ingestion.pipeline as pipeline_module
 from rag.ingestion.csv_loader import load_movies
 from rag.ingestion.pipeline import ingest_csv
 from rag.models.movie import Movie
@@ -110,6 +111,7 @@ def test_ingest_csv_embedding_failure() -> None:
     mock_provider.model_info.name = "test-model"
     mock_provider.model_info.dimension = 3
     mock_provider.embed_batch.return_value = []  # Failure
+    mock_provider.embed.return_value = []
 
     mock_usage = MagicMock()
     mock_usage.prompt_tokens = 0
@@ -133,3 +135,110 @@ def test_ingest_csv_embedding_failure() -> None:
         ingest_csv(mock_provider, mock_store)
 
     mock_store.upsert_batch.assert_not_called()
+
+
+def test_ingest_csv_falls_back_to_per_movie_embedding() -> None:
+    """Test that a failed batch falls back to individual movie embeddings."""
+    mock_provider = MagicMock()
+    mock_provider.model_info.name = "test-model"
+    mock_provider.model_info.dimension = 3
+    mock_provider.embed_batch.return_value = []
+
+    movie_one = Movie(
+        id=1,
+        title="First",
+        release_year=2000,
+        director="D1",
+        genre=["G1"],
+        cast=["C1"],
+        plot="First plot",
+    )
+    movie_two = Movie(
+        id=2,
+        title="Second",
+        release_year=2001,
+        director="D2",
+        genre=["G2"],
+        cast=["C2"],
+        plot="Second plot",
+    )
+
+    mock_provider.embed.side_effect = [[0.1, 0.2, 0.3], []]
+
+    mock_usage = MagicMock()
+    mock_usage.prompt_tokens = 5
+    mock_usage.estimated_cost_usd = 0.0
+    mock_provider.get_model_usage.return_value = mock_usage
+
+    mock_store = MagicMock()
+    mock_store.target_name.return_value = "movies_test_model_3"
+
+    with patch("rag.ingestion.csv_loader.load_movies", return_value=[movie_one, movie_two]):
+        ingest_csv(mock_provider, mock_store)
+
+    mock_provider.embed_batch.assert_called_once_with(["First plot", "Second plot"])
+    assert mock_provider.embed.call_count == 2
+    mock_store.upsert_batch.assert_called_once_with(
+        [movie_one],
+        [[0.1, 0.2, 0.3]],
+        mock_provider.model_info,
+    )
+
+
+def test_ingest_csv_writes_skipped_movies_report(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Test that ingestion persists machine-readable skipped movie details."""
+    report_dir = tmp_path / "reports"
+    monkeypatch.setattr(pipeline_module, "_REPORT_DIR", report_dir)
+    monkeypatch.setattr(
+        pipeline_module,
+        "_SKIPPED_MOVIES_REPORT_PATH",
+        report_dir / "skipped-movies.json",
+    )
+    monkeypatch.setattr(pipeline_module, "_COST_REPORT_PATH", report_dir / "cost-report.json")
+    monkeypatch.setattr(pipeline_module, "_OUTPUT_ENV_PATH", tmp_path / "ingestion-outputs.env")
+
+    mock_provider = MagicMock()
+    mock_provider.model_info.name = "test-model"
+    mock_provider.model_info.dimension = 3
+    mock_provider.embed_batch.return_value = []
+    mock_provider.embed.side_effect = [[0.1, 0.2, 0.3], []]
+
+    mock_usage = MagicMock()
+    mock_usage.prompt_tokens = 5
+    mock_usage.total_tokens = 5
+    mock_usage.estimated_cost_usd = 0.0
+    mock_provider.get_model_usage.return_value = mock_usage
+
+    mock_store = MagicMock()
+    mock_store.target_name.return_value = "movies_test_model_3"
+
+    movie_one = Movie(
+        id=1,
+        title="First",
+        release_year=2000,
+        director="D1",
+        genre=["G1"],
+        cast=["C1"],
+        plot="First plot",
+    )
+    movie_two = Movie(
+        id=2,
+        title="Second",
+        release_year=2001,
+        director="D2",
+        genre=["G2"],
+        cast=["C2"],
+        plot="Second plot that fails",
+    )
+
+    with patch("rag.ingestion.csv_loader.load_movies", return_value=[movie_one, movie_two]):
+        ingest_csv(mock_provider, mock_store)
+
+    report = (report_dir / "skipped-movies.json").read_text(encoding="utf-8")
+    assert '"skipped_movie_count": 1' in report
+    assert '"id": 2' in report
+    assert '"title": "Second"' in report
+    assert '"reason": "embedding_failed_after_batch_fallback"' in report

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -64,6 +64,7 @@ def test_ingest_csv_success() -> None:
     """Test the full ingestion pipeline orchestration."""
     mock_provider = MagicMock()
     mock_provider.model_info.name = "test-model"
+    mock_provider.model_info.dimension = 3
     mock_provider.embed_batch.return_value = [[0.1, 0.2]]
 
     mock_usage = MagicMock()
@@ -72,6 +73,7 @@ def test_ingest_csv_success() -> None:
     mock_provider.get_model_usage.return_value = mock_usage
 
     mock_store = MagicMock()
+    mock_store.target_name.return_value = "movies_test_model_3"
 
     mock_movie = Movie(
         id=1,
@@ -94,6 +96,7 @@ def test_ingest_csv_no_movies() -> None:
     """Test pipeline when no movies are loaded."""
     mock_provider = MagicMock()
     mock_store = MagicMock()
+    mock_store.target_name.return_value = "movies_test_model_3"
 
     with patch("rag.ingestion.csv_loader.load_movies", return_value=[]):
         ingest_csv(mock_provider, mock_store)
@@ -104,6 +107,8 @@ def test_ingest_csv_no_movies() -> None:
 def test_ingest_csv_embedding_failure() -> None:
     """Test pipeline handling of embedding failures."""
     mock_provider = MagicMock()
+    mock_provider.model_info.name = "test-model"
+    mock_provider.model_info.dimension = 3
     mock_provider.embed_batch.return_value = []  # Failure
 
     mock_usage = MagicMock()
@@ -112,6 +117,7 @@ def test_ingest_csv_embedding_failure() -> None:
     mock_provider.get_model_usage.return_value = mock_usage
 
     mock_store = MagicMock()
+    mock_store.target_name.return_value = "movies_test_model_3"
 
     mock_movie = Movie(
         id=1,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,52 +1,21 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import pytest
-
-from rag.config import settings
 from rag.main import main
 
 
-def test_main_openai(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "embedding_provider", "openai")
-    monkeypatch.setattr(settings, "openai_api_key", "test-key")
-    monkeypatch.setattr(settings, "qdrant_url", "http://test")
-    monkeypatch.setattr(settings, "qdrant_api_key_rw", "key")
-
+def test_main_uses_factories() -> None:
     with (
         patch("rag.main.dataset.download_data"),
-        patch("rag.main.OpenAIEmbeddingProvider"),
-        patch("rag.main.QdrantVectorStore"),
-        patch("rag.main.pipeline.ingest_csv") as mock_ingest,
+        patch("rag.main.get_embedding_provider") as get_provider,
+        patch("rag.main.get_vector_store") as get_store,
+        patch("rag.main.pipeline.ingest_csv") as ingest_csv,
     ):
-        main()
-        mock_ingest.assert_called_once()
+        provider = get_provider.return_value
+        provider.model_info.name = "text-embedding-3-large"
+        get_store.return_value = object()
 
-
-def test_main_gemini(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "embedding_provider", "gemini")
-    monkeypatch.setattr(settings, "google_api_key", "test-key")
-    monkeypatch.setattr(settings, "qdrant_url", "http://test")
-    monkeypatch.setattr(settings, "qdrant_api_key_rw", "key")
-
-    with (
-        patch("rag.main.dataset.download_data"),
-        patch("rag.main.GeminiEmbeddingProvider"),
-        patch("rag.main.QdrantVectorStore"),
-        patch("rag.main.pipeline.ingest_csv") as mock_ingest,
-    ):
-        main()
-        mock_ingest.assert_called_once()
-
-
-def test_main_unsupported(monkeypatch: pytest.MonkeyPatch) -> None:
-    # logger is bound at module import time, so we patch the module-level
-    # variable directly rather than patching get_logger.
-    monkeypatch.setattr(settings, "embedding_provider", "unsupported")
-
-    mock_logger = MagicMock()
-    with patch("rag.main.dataset.download_data"), patch("rag.main.logger", mock_logger):
         main()
 
-    mock_logger.error.assert_called()
-    error_calls = " ".join(str(c) for c in mock_logger.error.call_args_list)
-    assert "Unsupported embedding provider" in error_calls
+        get_provider.assert_called_once()
+        get_store.assert_called_once()
+        ingest_csv.assert_called_once_with(provider, get_store.return_value)

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,20 +1,14 @@
-from collections.abc import Sized
-from typing import cast
-
 from pytest import MonkeyPatch
 
 from rag.config import settings
 from rag.embeddings.base import EmbeddingModelMetadata
-from rag.models.movie import Movie
 from rag.vectorstore.qdrant_vectorstore import QdrantVectorStore
 
 
 def test_qdrant_vectorstore_uses_pydantic_settings(monkeypatch: MonkeyPatch) -> None:
-    """
-    Ensure the Qdrant client is correctly initialized from Pydantic settings.
-    """
     monkeypatch.setattr(settings, "qdrant_url", "https://qdrant.example")
     monkeypatch.setattr(settings, "qdrant_api_key_rw", "rw-test-key")
+    monkeypatch.setattr(settings, "qdrant_collection_prefix", "movies")
 
     captured: dict[str, str] = {}
 
@@ -23,58 +17,19 @@ def test_qdrant_vectorstore_uses_pydantic_settings(monkeypatch: MonkeyPatch) -> 
             captured["url"] = url
             captured["api_key"] = api_key
 
-    # Patch the client import within the rag package
-    monkeypatch.setattr("rag.vectorstore.qdrant_vectorstore.QdrantClient", DummyClient)
-
-    QdrantVectorStore()
-
-    assert captured == {
-        "url": "https://qdrant.example",
-        "api_key": "rw-test-key",
-    }
-
-
-def test_qdrant_vectorstore_batch_upsert(monkeypatch: MonkeyPatch) -> None:
-    """
-    Verify that batch upsert logic correctly calls the Qdrant SDK.
-    """
-    monkeypatch.setattr(settings, "qdrant_url", "https://qdrant.example")
-    monkeypatch.setattr(settings, "qdrant_api_key_rw", "rw-test-key")
-    monkeypatch.setattr(settings, "qdrant_collection_name", "movies-test")
-
-    captured: dict[str, object] = {}
-
-    class DummyClient:
-        def __init__(self, url: str, api_key: str) -> None:
-            pass
-
         def collection_exists(self, collection_name: str) -> bool:
             return True
 
-        def upsert(self, collection_name: str, points: list[object]) -> None:
-            captured["upsert_collection"] = collection_name
-            captured["points"] = points
+        def count(self, collection_name: str, exact: bool) -> object:
+            class Result:
+                count = 1
+
+            return Result()
 
     monkeypatch.setattr("rag.vectorstore.qdrant_vectorstore.QdrantClient", DummyClient)
 
     store = QdrantVectorStore()
-    model = EmbeddingModelMetadata(name="test-model", dimension=3072)
+    assert captured == {"url": "https://qdrant.example", "api_key": "rw-test-key"}
 
-    store.upsert_batch(
-        movies=[
-            Movie(
-                id=1,
-                title="Test Movie",
-                release_year=2024,
-                director="",
-                genre=[""],
-                cast=[""],
-                plot="",
-            )
-        ],
-        vectors=[[0.1, 0.2, 0.3]],
-        embedding_model=model,
-    )
-
-    assert captured["upsert_collection"] == "movies-test"
-    assert len(cast(Sized, captured["points"])) == 1
+    model = EmbeddingModelMetadata(name="BAAI/bge-m3", dimension=1024)
+    assert store.target_name(model) == "movies_baai_bge_m3_1024"

--- a/tests/test_vectorstore.py
+++ b/tests/test_vectorstore.py
@@ -1,3 +1,5 @@
+import sys
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -7,6 +9,8 @@ from rag.embeddings.base import EmbeddingModelMetadata
 from rag.models.movie import Movie
 from rag.vectorstore.chromadb_vectorstore import ChromaDBVectorStore
 from rag.vectorstore.naming import resolve_collection_name, sanitize_collection_token
+from rag.vectorstore.pgvector_vectorstore import PGVectorStore, cast_payload
+from rag.vectorstore.pinecone_vectorstore import PineconeVectorStore
 from rag.vectorstore.qdrant_vectorstore import QdrantVectorStore, QdrantVectorStoreError
 
 
@@ -28,6 +32,7 @@ def model_metadata() -> EmbeddingModelMetadata:
     return EmbeddingModelMetadata(name="BAAI/bge-m3", dimension=1024)
 
 
+# --- Naming Tests ---
 def test_sanitize_collection_token() -> None:
     assert sanitize_collection_token("BAAI/bge-m3") == "baai_bge_m3"
 
@@ -36,6 +41,7 @@ def test_resolve_collection_name(model_metadata: EmbeddingModelMetadata) -> None
     assert resolve_collection_name("movies", model_metadata) == "movies_baai_bge_m3_1024"
 
 
+# --- ChromaDB Tests ---
 def test_chromadb_uses_dynamic_target_name(
     sample_movie: Movie,
     model_metadata: EmbeddingModelMetadata,
@@ -53,13 +59,59 @@ def test_chromadb_uses_dynamic_target_name(
         mock_client.return_value.get_or_create_collection.assert_called_once_with(
             name="movies_baai_bge_m3_1024"
         )
+        mock_collection.upsert.assert_called_once()
 
 
+def test_chromadb_count(
+    model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "chromadb_persist_path", "test")
+    with patch("chromadb.PersistentClient") as mock_client:
+        mock_collection = MagicMock()
+        mock_collection.count.return_value = 5
+        mock_client.return_value.get_or_create_collection.return_value = mock_collection
+        store = ChromaDBVectorStore()
+        assert store.count(model_metadata) == 5
+
+
+def test_chromadb_search_empty(
+    model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "chromadb_persist_path", "test")
+    with patch("chromadb.PersistentClient") as mock_client:
+        mock_collection = MagicMock()
+        mock_collection.query.return_value = {"metadatas": []}
+        mock_client.return_value.get_or_create_collection.return_value = mock_collection
+        store = ChromaDBVectorStore()
+        assert store.search([0.1], 5, model_metadata) == []
+
+
+def test_chromadb_search_populated(
+    sample_movie: Movie, model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "chromadb_persist_path", "test")
+    with patch("chromadb.PersistentClient") as mock_client:
+        mock_collection = MagicMock()
+        mock_collection.query.return_value = {"metadatas": [[sample_movie.model_dump()]]}
+        mock_client.return_value.get_or_create_collection.return_value = mock_collection
+        store = ChromaDBVectorStore()
+        results = store.search([0.1], 5, model_metadata)
+        assert len(results) == 1
+        assert results[0].id == sample_movie.id
+
+
+# --- Qdrant Tests ---
 def test_qdrant_validate_env_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "qdrant_api_key_rw", None)
     monkeypatch.setattr(settings, "qdrant_url", None)
-
     with pytest.raises(QdrantVectorStoreError, match="QDRANT_API_KEY_RW is not defined"):
+        QdrantVectorStore()
+
+
+def test_qdrant_validate_env_error_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "qdrant_api_key_rw", "key")
+    monkeypatch.setattr(settings, "qdrant_url", None)
+    with pytest.raises(QdrantVectorStoreError, match="QDRANT_URL is not defined"):
         QdrantVectorStore()
 
 
@@ -80,3 +132,261 @@ def test_qdrant_uses_dynamic_collection_name(
         mock_client.return_value.upsert.assert_called_once()
         called_collection = mock_client.return_value.upsert.call_args.kwargs["collection_name"]
         assert called_collection == "movies_baai_bge_m3_1024"
+
+
+def test_qdrant_count_exists(
+    model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "qdrant_url", "http://test")
+    monkeypatch.setattr(settings, "qdrant_api_key_rw", "key")
+    with patch("rag.vectorstore.qdrant_vectorstore.QdrantClient") as mock_client:
+        mock_client.return_value.collection_exists.return_value = True
+        mock_client.return_value.count.return_value = MagicMock(count=10)
+        store = QdrantVectorStore()
+        assert store.count(model_metadata) == 10
+
+
+def test_qdrant_count_not_exists(
+    model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "qdrant_url", "http://test")
+    monkeypatch.setattr(settings, "qdrant_api_key_rw", "key")
+    with patch("rag.vectorstore.qdrant_vectorstore.QdrantClient") as mock_client:
+        mock_client.return_value.collection_exists.return_value = False
+        store = QdrantVectorStore()
+        assert store.count(model_metadata) == 0
+
+
+def test_qdrant_search(
+    sample_movie: Movie, model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "qdrant_url", "http://test")
+    monkeypatch.setattr(settings, "qdrant_api_key_rw", "key")
+    with patch("rag.vectorstore.qdrant_vectorstore.QdrantClient") as mock_client:
+        mock_client.return_value.collection_exists.return_value = False  # should create
+        mock_client.return_value.query_points.return_value = MagicMock(
+            points=[MagicMock(payload=sample_movie.model_dump())]
+        )
+        store = QdrantVectorStore()
+        results = store.search([0.1], 5, model_metadata)
+        assert len(results) == 1
+        assert results[0].id == sample_movie.id
+        mock_client.return_value.create_collection.assert_called_once()
+
+
+# --- PGVector Tests ---
+def test_pgvector_missing_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "pgvector_dsn", None)
+    with pytest.raises(ValueError, match="PGVECTOR_DSN is not defined"):
+        PGVectorStore()
+
+
+def test_pgvector_missing_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "pgvector_dsn", "postgres://test")
+    with (
+        patch.dict(sys.modules, {"psycopg": None}),
+        pytest.raises(RuntimeError, match="PGVector support requires"),
+    ):
+        PGVectorStore()
+
+
+def test_pgvector_count(
+    model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "pgvector_dsn", "postgres://test")
+    mock_psycopg = MagicMock()
+    mock_register = MagicMock()
+    with patch.dict(
+        sys.modules,
+        {"psycopg": mock_psycopg, "pgvector.psycopg": MagicMock(register_vector=mock_register)},
+    ):
+        store = PGVectorStore()
+        mock_conn = MagicMock()
+        mock_conn.__enter__.return_value = mock_conn
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__.return_value = mock_cursor
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = [42]
+        store._psycopg.connect.return_value = mock_conn
+
+        assert store.count(model_metadata) == 42
+        mock_cursor.execute.assert_called_with(
+            'SELECT COUNT(*) FROM "public_movies_baai_bge_m3_1024"'
+        )
+
+
+def test_pgvector_count_empty(
+    model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "pgvector_dsn", "postgres://test")
+    mock_psycopg = MagicMock()
+    mock_register = MagicMock()
+    with patch.dict(
+        sys.modules,
+        {"psycopg": mock_psycopg, "pgvector.psycopg": MagicMock(register_vector=mock_register)},
+    ):
+        store = PGVectorStore()
+        mock_conn = MagicMock()
+        mock_conn.__enter__.return_value = mock_conn
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__.return_value = mock_cursor
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = None
+        store._psycopg.connect.return_value = mock_conn
+
+        assert store.count(model_metadata) == 0
+
+
+def test_pgvector_upsert(
+    sample_movie: Movie, model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "pgvector_dsn", "postgres://test")
+    mock_psycopg = MagicMock()
+    mock_register = MagicMock()
+    with patch.dict(
+        sys.modules,
+        {"psycopg": mock_psycopg, "pgvector.psycopg": MagicMock(register_vector=mock_register)},
+    ):
+        store = PGVectorStore()
+        mock_conn = MagicMock()
+        mock_conn.__enter__.return_value = mock_conn
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__.return_value = mock_cursor
+        mock_conn.cursor.return_value = mock_cursor
+        store._psycopg.connect.return_value = mock_conn
+
+        store.upsert(sample_movie, [0.1], model_metadata)
+        assert mock_cursor.execute.call_count >= 3  # extension, table, insert
+        mock_conn.commit.assert_called()
+
+
+def test_pgvector_search(
+    sample_movie: Movie, model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "pgvector_dsn", "postgres://test")
+    mock_psycopg = MagicMock()
+    mock_register = MagicMock()
+    with patch.dict(
+        sys.modules,
+        {"psycopg": mock_psycopg, "pgvector.psycopg": MagicMock(register_vector=mock_register)},
+    ):
+        store = PGVectorStore()
+        mock_conn = MagicMock()
+        mock_conn.__enter__.return_value = mock_conn
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__.return_value = mock_cursor
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchall.return_value = [[sample_movie.model_dump()]]
+        store._psycopg.connect.return_value = mock_conn
+
+        results = store.search([0.1], 5, model_metadata)
+        assert len(results) == 1
+        assert results[0].id == sample_movie.id
+
+
+def test_cast_payload_str() -> None:
+
+    assert cast_payload('{"a": 1}') == {"a": 1}
+
+
+def test_cast_payload_dict() -> None:
+    assert cast_payload({"a": 1}) == {"a": 1}
+
+
+# --- Pinecone Tests ---
+def test_pinecone_missing_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "pinecone_api_key", None)
+    with pytest.raises(ValueError, match="PINECONE_API_KEY is not defined"):
+        PineconeVectorStore()
+
+
+def test_pinecone_missing_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "pinecone_api_key", "test")
+    with (
+        patch.dict(sys.modules, {"pinecone": None}),
+        pytest.raises(RuntimeError, match="Pinecone support requires"),
+    ):
+        PineconeVectorStore()
+
+
+def test_pinecone_count(
+    model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "pinecone_api_key", "test")
+    mock_pinecone = MagicMock()
+    with patch.dict(
+        sys.modules, {"pinecone": MagicMock(Pinecone=mock_pinecone, ServerlessSpec=MagicMock())}
+    ):
+        store = PineconeVectorStore()
+        mock_index = MagicMock()
+        mock_index.describe_index_stats.return_value = {
+            "namespaces": {"movies_baai_bge_m3_1024": {"vector_count": 99}}
+        }
+        store._index = mock_index
+        assert store.count(model_metadata) == 99
+
+
+def test_pinecone_count_no_namespace(
+    model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "pinecone_api_key", "test")
+    mock_pinecone = MagicMock()
+    with patch.dict(
+        sys.modules, {"pinecone": MagicMock(Pinecone=mock_pinecone, ServerlessSpec=MagicMock())}
+    ):
+        store = PineconeVectorStore()
+        mock_index = MagicMock()
+        mock_index.describe_index_stats.return_value = {"namespaces": {}}
+        store._index = mock_index
+        assert store.count(model_metadata) == 0
+
+
+def test_pinecone_upsert(
+    sample_movie: Movie, model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "pinecone_api_key", "test")
+    mock_pinecone = MagicMock()
+    with patch.dict(
+        sys.modules, {"pinecone": MagicMock(Pinecone=mock_pinecone, ServerlessSpec=MagicMock())}
+    ):
+        store = PineconeVectorStore()
+        mock_index = MagicMock()
+        store._index = mock_index
+        store.upsert(sample_movie, [0.1], model_metadata)
+        mock_index.upsert.assert_called_once()
+
+
+def test_pinecone_search(
+    sample_movie: Movie, model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "pinecone_api_key", "test")
+    mock_pinecone = MagicMock()
+    with patch.dict(
+        sys.modules, {"pinecone": MagicMock(Pinecone=mock_pinecone, ServerlessSpec=MagicMock())}
+    ):
+        store = PineconeVectorStore()
+        mock_index = MagicMock()
+        mock_index.query.return_value = {"matches": [{"metadata": sample_movie.model_dump()}]}
+        store._index = mock_index
+        results = store.search([0.1], 5, model_metadata)
+        assert len(results) == 1
+        assert results[0].id == sample_movie.id
+
+
+def test_pinecone_get_index_no_host(
+    model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "pinecone_api_key", "test")
+    monkeypatch.setattr(settings, "pinecone_index_host", None)
+    mock_pinecone = MagicMock()
+    with patch.dict(
+        sys.modules, {"pinecone": MagicMock(Pinecone=mock_pinecone, ServerlessSpec=MagicMock())}
+    ):
+        store = PineconeVectorStore()
+        cast(MagicMock, store.client.has_index).return_value = False
+        cast(MagicMock, store.client.describe_index).return_value = {"host": "my-host"}
+
+        index = store._get_index(model_metadata)
+        cast(MagicMock, store.client.create_index).assert_called_once()
+        cast(MagicMock, store.client.Index).assert_called_with(host="my-host")
+        assert index is not None

--- a/tests/test_vectorstore.py
+++ b/tests/test_vectorstore.py
@@ -6,6 +6,7 @@ from rag.config import settings
 from rag.embeddings.base import EmbeddingModelMetadata
 from rag.models.movie import Movie
 from rag.vectorstore.chromadb_vectorstore import ChromaDBVectorStore
+from rag.vectorstore.naming import resolve_collection_name, sanitize_collection_token
 from rag.vectorstore.qdrant_vectorstore import QdrantVectorStore, QdrantVectorStoreError
 
 
@@ -24,112 +25,58 @@ def sample_movie() -> Movie:
 
 @pytest.fixture
 def model_metadata() -> EmbeddingModelMetadata:
-    return EmbeddingModelMetadata(name="test-model", dimension=3)
+    return EmbeddingModelMetadata(name="BAAI/bge-m3", dimension=1024)
 
 
-def test_chromadb_upsert(sample_movie: Movie, model_metadata: EmbeddingModelMetadata) -> None:
-    with patch("chromadb.Client") as mock_client:
+def test_sanitize_collection_token() -> None:
+    assert sanitize_collection_token("BAAI/bge-m3") == "baai_bge_m3"
+
+
+def test_resolve_collection_name(model_metadata: EmbeddingModelMetadata) -> None:
+    assert resolve_collection_name("movies", model_metadata) == "movies_baai_bge_m3_1024"
+
+
+def test_chromadb_uses_dynamic_target_name(
+    sample_movie: Movie,
+    model_metadata: EmbeddingModelMetadata,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "qdrant_collection_prefix", "movies")
+    monkeypatch.setattr(settings, "chromadb_persist_path", "outputs/chromadb-test")
+
+    with patch("chromadb.PersistentClient") as mock_client:
         mock_collection = MagicMock()
         mock_client.return_value.get_or_create_collection.return_value = mock_collection
-
         store = ChromaDBVectorStore()
         store.upsert(sample_movie, [0.1, 0.2, 0.3], model_metadata)
 
-        mock_collection.add.assert_called_once()
-
-
-def test_chromadb_upsert_batch(sample_movie: Movie, model_metadata: EmbeddingModelMetadata) -> None:
-    with patch("chromadb.Client") as mock_client:
-        mock_collection = MagicMock()
-        mock_client.return_value.get_or_create_collection.return_value = mock_collection
-
-        store = ChromaDBVectorStore()
-        store.upsert_batch([sample_movie], [[0.1, 0.2, 0.3]], model_metadata)
-
-        mock_collection.add.assert_called_once()
-
-
-def test_chromadb_search(model_metadata: EmbeddingModelMetadata) -> None:
-    with patch("chromadb.Client") as mock_client:
-        mock_collection = MagicMock()
-        mock_collection.query.return_value = {
-            "metadatas": [
-                [
-                    {
-                        "id": 1,
-                        "title": "T",
-                        "release_year": 2000,
-                        "director": "D",
-                        "genre": ["G"],
-                        "cast": ["C"],
-                        "plot": "P",
-                    }
-                ]
-            ]
-        }
-        mock_client.return_value.get_or_create_collection.return_value = mock_collection
-
-        store = ChromaDBVectorStore()
-        results = store.search([0.1, 0.2, 0.3], top_k=1, embedding_model=model_metadata)
-
-        assert len(results) == 1
-        assert results[0].title == "T"
+        mock_client.return_value.get_or_create_collection.assert_called_once_with(
+            name="movies_baai_bge_m3_1024"
+        )
 
 
 def test_qdrant_validate_env_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "qdrant_api_key_rw", "")
+    monkeypatch.setattr(settings, "qdrant_api_key_rw", None)
+    monkeypatch.setattr(settings, "qdrant_url", None)
+
     with pytest.raises(QdrantVectorStoreError, match="QDRANT_API_KEY_RW is not defined"):
         QdrantVectorStore()
 
 
-def test_qdrant_upsert(
-    sample_movie: Movie, model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
+def test_qdrant_uses_dynamic_collection_name(
+    sample_movie: Movie,
+    model_metadata: EmbeddingModelMetadata,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(settings, "qdrant_url", "http://test")
     monkeypatch.setattr(settings, "qdrant_api_key_rw", "key")
+    monkeypatch.setattr(settings, "qdrant_collection_prefix", "movies")
 
     with patch("rag.vectorstore.qdrant_vectorstore.QdrantClient") as mock_client:
         mock_client.return_value.collection_exists.return_value = True
         store = QdrantVectorStore()
         store.upsert(sample_movie, [0.1, 0.2, 0.3], model_metadata)
+
         mock_client.return_value.upsert.assert_called_once()
-
-
-def test_qdrant_upsert_creates_collection(
-    sample_movie: Movie, model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(settings, "qdrant_url", "http://test")
-    monkeypatch.setattr(settings, "qdrant_api_key_rw", "key")
-
-    with patch("rag.vectorstore.qdrant_vectorstore.QdrantClient") as mock_client:
-        mock_client.return_value.collection_exists.return_value = False
-        store = QdrantVectorStore()
-        store.upsert(sample_movie, [0.1, 0.2, 0.3], model_metadata)
-        mock_client.return_value.create_collection.assert_called_once()
-
-
-def test_qdrant_search(
-    model_metadata: EmbeddingModelMetadata, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(settings, "qdrant_url", "http://test")
-    monkeypatch.setattr(settings, "qdrant_api_key_rw", "key")
-
-    with patch("rag.vectorstore.qdrant_vectorstore.QdrantClient") as mock_client:
-        mock_client.return_value.collection_exists.return_value = True
-        mock_results = MagicMock()
-        mock_point = MagicMock()
-        mock_point.payload = {
-            "id": 1,
-            "title": "T",
-            "release_year": 2000,
-            "director": "D",
-            "genre": ["G"],
-            "cast": ["C"],
-            "plot": "P",
-        }
-        mock_results.points = [mock_point]
-        mock_client.return_value.query_points.return_value = mock_results
-
-        store = QdrantVectorStore()
-        results = store.search([0.1, 0.2, 0.3], top_k=1, embedding_model=model_metadata)
-        assert len(results) == 1
+        called_collection = mock_client.return_value.upsert.call_args.kwargs["collection_name"]
+        assert called_collection == "movies_baai_bge_m3_1024"


### PR DESCRIPTION
## What and why

Implements the ADR 0008 provider/vector store matrix for `movie-finder-rag`.

This adds provider-backed embedding selection, dynamic collection naming, Qdrant legacy collection migration, backup/report artifact handling, and ingestion fallback behavior for provider-side batch failures. The ingestion fallback is needed because local Ollama models can reject long inputs for a single movie; the pipeline now falls back to per-movie embedding, inserts successful records, and writes an auditable skipped-movies report for CI/Jenkins artifacts.

The PR also gates draft PR checks in GitHub Actions and isolates pytest from CI/local `.env` values so test collection does not depend on real Qdrant credentials.

Closes #21.
Closes #10.
Refs #6.

AI authoring disclosure: OpenAI Codex CLI using GPT-5.

## How to test

1. `make test`
2. `make test-coverage`
3. Create or configure provider-specific `.env` values and run `make ingest`.
4. Run backup/migration targets as needed and inspect `outputs/reports/**` plus `outputs/backups/qdrant/**`.

## Checklist

### Code quality

- [ ] `make lint` passes with zero errors
- [x] `make test` passes with zero failures
- [x] New logic has unit tests
- [x] No real API calls in tests (mocked at HTTP boundary)
- [x] No secrets or credentials added to code or test fixtures

### Documentation

- [x] Public functions/classes have type annotations
- [x] New environment variables added to the relevant `.env.example`
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [x] README updated if the public interface or setup steps changed

### Review

- [x] PR description links the issue and discloses the AI authoring tool + model
- [x] Any AI-assisted review comment or approval discloses the review tool + model

### Submodule changes _(if applicable)_

- [ ] Submodule pointer updated to a tagged release, not a raw commit
- [ ] Backend `pyproject.toml` / workspace config updated if dependencies changed

### Release _(for release PRs only)_

- [ ] `version` bumped in `pyproject.toml`
- [ ] `[Unreleased]` section moved to the new version in `CHANGELOG.md`
- [ ] Git tag created after merge: `git tag vX.Y.Z && git push origin --tags`

## Notes

- `make test` passed with 97 tests.
- `make test-coverage` passed with 97 tests and generated coverage artifacts.
- Pre-commit during commit passed, including mypy, ruff check, and ruff format.
- `make lint` was attempted locally but the working tree contains untracked `evaluate_wiki_dump.py`; Ruff scans that local file even though it is not included in this PR.
- Draft PR checks are intentionally skipped in GitHub Actions. Jenkins draft/branch discovery should be narrowed in Jenkins multibranch configuration rather than in this repo's `Jenkinsfile`.
- Artifact exports are grouped locally under `~/Downloads/movie-finder-rag/provider-vectorstore-artifacts-20260425`.
