### PR TITLE
[codex] add chunking experiment framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build/
 .coverage
 reports/
 outputs/
+experiments/
 
 # IDEs
 .vscode/*

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "CONTRIBUTING.md",
         "hashed_secret": "eedbde13d0baad04070dea253214aae4826b044e",
         "is_verified": true,
-        "line_number": 243
+        "line_number": 285
       }
     ],
     "tests/conftest.py": [
@@ -163,5 +163,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-30T00:48:52Z"
+  "generated_at": "2026-05-08T14:15:33Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+**Chunking strategy experiment framework (issue #8 / parent #31)**
+
+- `src/rag/chunking/` — added the `Chunker` abstraction plus flat, fixed-size, sentence, and
+  field-based strategies. `CHUNKING_STRATEGY=flat` is the default and preserves the current
+  full-movie embedding behavior.
+- `src/rag/ingestion/pipeline.py` — ingestion now receives an explicit chunker dependency and
+  embeds generated chunks with chunk metadata in the stored payload.
+- `scripts/chunking_experiment.py` — local ChromaDB-only experiment harness that holds provider,
+  corpus, query set, and top-k fixed while varying chunking strategy; writes CSV and HTML reports
+  identifying the highest-MRR candidate before any production Qdrant deployment.
+- `Makefile` — added `chunking-experiment` target and ignored generated `experiments/` artifacts.
+- `CONTRIBUTING.md` — documented chunking settings, local experiment execution, and the >5% MRR
+  adoption gate for field-based chunking.
+
 **Textual TUI — retrieval evaluation app (issue #23)**
 
 - `tui/` — new top-level package containing the full Textual TUI for retrieval evaluation:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,12 @@ Plots dataset from Kaggle, embeds each record with OpenAI/Gemini, and writes vec
 1. [Development setup](#development-setup)
 2. [Project structure](#project-structure)
 3. [Running the pipeline](#running-the-pipeline)
-4. [Adding an embedding provider](#adding-an-embedding-provider)
-5. [Adding a vector store backend](#adding-a-vector-store-backend)
-6. [Testing strategy](#testing-strategy)
-7. [CI/CD pipeline](#ci-cd-pipeline)
-8. [Sharing outputs with the chain team](#sharing-outputs-with-the-chain-team)
+4. [Chunking experiments](#chunking-experiments)
+5. [Adding an embedding provider](#adding-an-embedding-provider)
+6. [Adding a vector store backend](#adding-a-vector-store-backend)
+7. [Testing strategy](#testing-strategy)
+8. [CI/CD pipeline](#ci-cd-pipeline)
+9. [Sharing outputs with the chain team](#sharing-outputs-with-the-chain-team)
 
 ---
 
@@ -83,6 +84,23 @@ make ingest
 ```
 
 This runs the runtime image against external Qdrant Cloud using the values in `.env`.
+
+The ingestion pipeline always receives an explicit chunking strategy. The default
+`CHUNKING_STRATEGY=flat` preserves the current full-movie embedding behavior. Other strategy
+settings are available for experiments:
+
+```bash
+CHUNKING_STRATEGY=fixed_size
+CHUNK_SIZE=160
+CHUNK_OVERLAP=32
+
+CHUNKING_STRATEGY=sentence
+CHUNK_MIN_SENTENCES=1
+CHUNK_MAX_SENTENCES=4
+
+CHUNKING_STRATEGY=field
+CHUNK_FIELDS=plot,cast,metadata
+```
 
 ### Common quality commands
 
@@ -161,6 +179,30 @@ After ingestion, regenerate `outputs/reports/cost-report.json` from `ingestion-o
 ```bash
 make cost-report
 ```
+
+---
+
+## Chunking Experiments
+
+Issue #31 is a research spike, not an open-ended production migration. Run the sweep only after the
+baseline retrieval metrics are available, then compare candidate strategies against the flat
+baseline.
+
+```bash
+make chunking-experiment
+```
+
+Useful local spike options:
+
+```bash
+CHUNKING_EXPERIMENT_ARGS="--limit 1000 --top-k 5" make chunking-experiment
+```
+
+The script writes `experiments/chunking-results.csv` and caches embeddings under
+`outputs/cache/chunking-embeddings.json`, so repeated sweep entries do not re-embed the same text.
+Do not commit generated experiment results or cache files. Treat field-based improvements as
+adoptable only if MRR improves by more than 5% over flat; adopting field-based retrieval requires
+coordinating the query-time retrieval contract with `chain/`.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 .PHONY: help init build setup clean clean-docker \
 	editor-up editor-down ci-down shell logs up down  run run-dev \
 	lint format fix typecheck test test-coverage pre-commit detect-secrets check \
-	backup cost-report qdrant-live-eval retrieve validate tui
+	backup cost-report qdrant-live-eval chunking-experiment retrieve validate tui
 
 
 .DEFAULT_GOAL := help
@@ -41,6 +41,7 @@ COVERAGE_HTML ?= reports/htmlcov
 JUNIT_XML ?= reports/junit.xml
 BACKUP_ARGS ?=
 QDRANT_EVAL_ARGS ?=
+CHUNKING_EXPERIMENT_ARGS ?=
 
 # ---------------------------------------------------------------------------
 # exec when running, run --rm otherwise — avoids container startup overhead
@@ -100,6 +101,7 @@ help:
 	@echo "    backup         Runs the Docker-backed backup utility and writes artifacts under outputs/"
 	@echo "    cost-report    Refreshes outputs/reports/cost-report.json from ingestion outputs"
 	@echo "    qdrant-live-eval  Evaluates existing Qdrant collections and writes HTML/JSON reports"
+	@echo "    chunking-experiment  Runs chunking strategy sweep and writes experiments CSV"
 	@echo "    retrieve       Runs the interactive CLI to validate retrieval logic"
 	@echo "    tui            Launches the full Textual TUI for retrieval evaluation"
 	@echo "    validate       Runs the post-ingest validation script"
@@ -199,6 +201,9 @@ cost-report:
 
 qdrant-live-eval:
 	$(call exec_or_run,python scripts/evaluate_qdrant_collections.py $(QDRANT_EVAL_ARGS))
+
+chunking-experiment:
+	$(call exec_or_run,python scripts/chunking_experiment.py $(CHUNKING_EXPERIMENT_ARGS))
 
 retrieve:
 	$(call exec_or_run,python scripts/retrieve.py)

--- a/scripts/chunking_experiment.py
+++ b/scripts/chunking_experiment.py
@@ -1,0 +1,413 @@
+import argparse
+import csv
+import hashlib
+import html
+import json
+from collections.abc import Iterable
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import chromadb
+from chromadb.api import ClientAPI
+
+from evaluate_qdrant_collections import EVAL_QUERIES, EvalQuery
+from rag.chunking.base import Chunker
+from rag.chunking.field import FieldChunker
+from rag.chunking.fixed_size import FixedSizeChunker
+from rag.chunking.flat import FlatChunker
+from rag.chunking.sentence import SentenceChunker
+from rag.embeddings.base import EmbeddingProvider
+from rag.embeddings.factory import get_embedding_provider
+from rag.ingestion.csv_loader import load_movies
+from rag.models.movie import Movie
+
+DEFAULT_OUTPUT_PATH = Path("experiments/chunking-results.csv")
+DEFAULT_REPORT_PATH = Path("experiments/chunking-report.html")
+DEFAULT_CACHE_PATH = Path("outputs/cache/chunking-embeddings.json")
+DEFAULT_CHROMADB_PATH = Path("outputs/chromadb/chunking-experiment")
+DEFAULT_TOP_K = 5
+
+
+@dataclass(frozen=True, slots=True)
+class StrategySpec:
+    name: str
+    params: dict[str, Any]
+    chunker: Chunker
+
+
+@dataclass(frozen=True, slots=True)
+class EmbeddedChunk:
+    movie: Movie
+    chunk_text: str
+    chunk_index: int
+    vector: list[float]
+
+
+@dataclass(frozen=True, slots=True)
+class RankedMovie:
+    movie: Movie
+    score: float
+
+
+@dataclass(frozen=True, slots=True)
+class ExperimentConfig:
+    top_k: int
+    chromadb_path: Path
+    output_path: Path
+    report_path: Path
+
+
+class EmbeddingCache:
+    """Persistent text embedding cache for strategy sweeps."""
+
+    def __init__(self, path: Path, provider: EmbeddingProvider) -> None:
+        self.path = path
+        self.provider = provider
+        self._vectors = self._load()
+
+    def embed(self, text: str) -> list[float]:
+        key = _text_key(self.provider.model_info.name, text)
+        cached = self._vectors.get(key)
+        if cached is not None:
+            return cached
+        vector = self.provider.embed(text)
+        self._vectors[key] = vector
+        return vector
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(self._vectors), encoding="utf-8")
+
+    def _load(self) -> dict[str, list[float]]:
+        if not self.path.exists():
+            return {}
+        data = json.loads(self.path.read_text(encoding="utf-8"))
+        return {str(key): [float(value) for value in values] for key, values in data.items()}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run chunking strategy retrieval experiments.")
+    parser.add_argument("--dataset", default="dataset/wiki_movie_plots_deduped.csv")
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT_PATH))
+    parser.add_argument("--report", default=str(DEFAULT_REPORT_PATH))
+    parser.add_argument("--cache", default=str(DEFAULT_CACHE_PATH))
+    parser.add_argument("--chromadb-path", default=str(DEFAULT_CHROMADB_PATH))
+    parser.add_argument("--top-k", type=int, default=DEFAULT_TOP_K)
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Optional corpus limit for local spike runs. Omit for the full supported dataset.",
+    )
+    args = parser.parse_args()
+
+    provider = get_embedding_provider()
+    cache = EmbeddingCache(Path(args.cache), provider)
+    movies = load_movies(args.dataset)
+    if args.limit is not None:
+        movies = movies[: args.limit]
+
+    config = ExperimentConfig(
+        top_k=args.top_k,
+        chromadb_path=Path(args.chromadb_path),
+        output_path=Path(args.output),
+        report_path=Path(args.report),
+    )
+    rows = run_experiment(movies, EVAL_QUERIES, strategy_matrix(), cache, config)
+    cache.save()
+    write_csv(rows, config.output_path)
+    write_report(rows, config.report_path)
+    print(f"Wrote {len(rows)} chunking experiment rows to {config.output_path}")
+    print(f"Wrote chunking experiment report to {config.report_path}")
+
+
+def run_experiment(
+    movies: list[Movie],
+    queries: list[EvalQuery],
+    strategies: list[StrategySpec],
+    cache: EmbeddingCache,
+    config: ExperimentConfig,
+) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    query_vectors = {query.query_id: cache.embed(query.text) for query in queries}
+    client = chromadb.PersistentClient(path=str(config.chromadb_path))
+
+    for strategy in strategies:
+        chunks = embed_chunks(movies, strategy.chunker, cache)
+        collection = rebuild_collection(client, strategy, chunks)
+        per_query = [
+            score_query(query, query_vectors[query.query_id], collection, config.top_k)
+            for query in queries
+        ]
+        rows.append(
+            {
+                "strategy": strategy.name,
+                "params": json.dumps(strategy.params, sort_keys=True),
+                "movie_count": str(len(movies)),
+                "chunk_count": str(len(chunks)),
+                "top_k": str(config.top_k),
+                "precision_at_k": f"{mean(row['precision_at_k'] for row in per_query):.6f}",
+                "recall_at_k": f"{mean(row['recall_at_k'] for row in per_query):.6f}",
+                "mrr": f"{mean(row['reciprocal_rank'] for row in per_query):.6f}",
+                "hit_rate_at_k": f"{mean(row['hit'] for row in per_query):.6f}",
+                "chromadb_path": str(config.chromadb_path),
+                "collection_name": collection.name,
+            }
+        )
+
+    return rows
+
+
+def strategy_matrix() -> list[StrategySpec]:
+    return [
+        StrategySpec("flat", {}, FlatChunker()),
+        StrategySpec("fixed_size", {"chunk_size": 120, "overlap": 24}, FixedSizeChunker(120, 24)),
+        StrategySpec(
+            "field",
+            {"fields": ["plot", "cast", "metadata"]},
+            FieldChunker(["plot", "cast", "metadata"]),
+        ),
+        StrategySpec(
+            "sentence",
+            {"min_sentences": 1, "max_sentences": 4},
+            SentenceChunker(min_sentences=1, max_sentences=4),
+        ),
+    ]
+
+
+def embed_chunks(
+    movies: Iterable[Movie],
+    chunker: Chunker,
+    cache: EmbeddingCache,
+) -> list[EmbeddedChunk]:
+    chunks: list[EmbeddedChunk] = []
+    for movie in movies:
+        for chunk in chunker.chunk(movie):
+            chunks.append(
+                EmbeddedChunk(
+                    movie=movie,
+                    chunk_text=chunk.text,
+                    chunk_index=chunk.chunk_index,
+                    vector=cache.embed(chunk.text),
+                )
+            )
+    return chunks
+
+
+def rebuild_collection(
+    client: ClientAPI,
+    strategy: StrategySpec,
+    chunks: list[EmbeddedChunk],
+) -> chromadb.Collection:
+    collection_name = f"chunking_{strategy.name}_{_params_hash(strategy.params)}"
+    with suppress(ValueError):
+        client.delete_collection(collection_name)
+
+    collection = client.create_collection(
+        name=collection_name,
+        metadata={
+            "experiment": "chunking",
+            "strategy": strategy.name,
+            "params": json.dumps(strategy.params, sort_keys=True),
+            "hnsw:space": "cosine",
+        },
+    )
+    if not chunks:
+        return collection
+
+    collection.add(
+        ids=[f"{chunk.movie.id}:{chunk.chunk_index}" for chunk in chunks],
+        embeddings=cast(Any, [chunk.vector for chunk in chunks]),
+        documents=[chunk.chunk_text for chunk in chunks],
+        metadatas=[
+            {
+                "movie_id": chunk.movie.id,
+                "title": chunk.movie.title,
+                "release_year": chunk.movie.release_year,
+                "chunk_index": chunk.chunk_index,
+                "strategy": strategy.name,
+            }
+            for chunk in chunks
+        ],
+    )
+    return collection
+
+
+def score_query(
+    query: EvalQuery,
+    query_vector: list[float],
+    collection: chromadb.Collection,
+    top_k: int,
+) -> dict[str, float]:
+    ranked = rank_movies(collection, query_vector, top_k)
+    expected_titles = {title.casefold() for title in query.expected_titles}
+    retrieved_titles = [movie.movie.title.casefold() for movie in ranked]
+    hits = expected_titles.intersection(retrieved_titles)
+    reciprocal_rank = 0.0
+    for rank, movie in enumerate(ranked, start=1):
+        if movie.movie.title.casefold() in expected_titles:
+            reciprocal_rank = 1.0 / rank
+            break
+
+    return {
+        "precision_at_k": len(hits) / top_k,
+        "recall_at_k": len(hits) / len(expected_titles),
+        "reciprocal_rank": reciprocal_rank,
+        "hit": 1.0 if hits else 0.0,
+    }
+
+
+def rank_movies(
+    collection: chromadb.Collection,
+    query_vector: list[float],
+    top_k: int,
+) -> list[RankedMovie]:
+    chunk_count = collection.count()
+    if chunk_count == 0:
+        return []
+
+    result = collection.query(
+        query_embeddings=cast(Any, [query_vector]),
+        n_results=min(chunk_count, max(top_k * 10, top_k)),
+        include=["distances", "metadatas"],
+    )
+    metadatas = (result.get("metadatas") or [[]])[0]
+    distances = (result.get("distances") or [[]])[0]
+
+    best_by_movie_id: dict[int, RankedMovie] = {}
+    for metadata, distance in zip(metadatas, distances, strict=True):
+        if metadata is None:
+            continue
+        payload = cast(dict[str, object], metadata)
+        movie_id = int(cast(str | int | float, payload["movie_id"]))
+        movie = Movie(
+            id=movie_id,
+            title=str(payload["title"]),
+            release_year=int(cast(str | int | float, payload["release_year"])),
+            director="",
+            genre=[],
+            cast=[],
+            plot="",
+        )
+        score = 1.0 - float(distance)
+        current = best_by_movie_id.get(movie_id)
+        if current is None or score > current.score:
+            best_by_movie_id[movie_id] = RankedMovie(movie=movie, score=score)
+    return sorted(best_by_movie_id.values(), key=lambda item: item.score, reverse=True)[:top_k]
+
+
+def write_csv(rows: list[dict[str, str]], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "strategy",
+        "params",
+        "movie_count",
+        "chunk_count",
+        "top_k",
+        "precision_at_k",
+        "recall_at_k",
+        "mrr",
+        "hit_rate_at_k",
+        "chromadb_path",
+        "collection_name",
+    ]
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_report(rows: list[dict[str, str]], report_path: Path) -> None:
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    best = max(rows, key=lambda row: float(row["mrr"]), default=None)
+    baseline = next((row for row in rows if row["strategy"] == "flat"), None)
+    delta = 0.0
+    if best is not None and baseline is not None:
+        baseline_mrr = float(baseline["mrr"])
+        if baseline_mrr > 0.0:
+            delta = (float(best["mrr"]) - baseline_mrr) / baseline_mrr
+
+    body_rows = "\n".join(
+        "<tr>"
+        f"<td>{html.escape(row['strategy'])}</td>"
+        f"<td><code>{html.escape(row['params'])}</code></td>"
+        f"<td>{html.escape(row['chunk_count'])}</td>"
+        f"<td>{float(row['precision_at_k']):.4f}</td>"
+        f"<td>{float(row['recall_at_k']):.4f}</td>"
+        f"<td>{float(row['mrr']):.4f}</td>"
+        f"<td>{float(row['hit_rate_at_k']):.4f}</td>"
+        f"<td><code>{html.escape(row['collection_name'])}</code></td>"
+        "</tr>"
+        for row in rows
+    )
+    recommendation = "No strategies were evaluated."
+    if best is not None:
+        recommendation = (
+            f"Best strategy: {html.escape(best['strategy'])} with MRR {float(best['mrr']):.4f}. "
+            f"MRR delta vs flat: {delta:.2%}."
+        )
+        if best["strategy"] == "field" and delta > 0.05:
+            recommendation += " Field-based chunking meets the >5% adoption gate."
+        elif best["strategy"] != "flat":
+            recommendation += " Treat this as an experimental candidate; production adoption still requires chain retrieval coordination."
+        else:
+            recommendation += " Keep flat chunking unless a future run clears the adoption gate."
+
+    report_path.write_text(
+        f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Chunking Experiment Report</title>
+<style>
+body {{ font-family: Arial, sans-serif; color:#17202a; margin:2rem; }}
+table {{ border-collapse: collapse; width:100%; }}
+th, td {{ border:1px solid #d5d8dc; padding:.55rem; text-align:left; vertical-align:top; }}
+th {{ background:#1f618d; color:white; }}
+code {{ white-space:nowrap; }}
+.summary {{ background:#f4f6f7; border:1px solid #d5d8dc; padding:1rem; margin-bottom:1rem; }}
+</style>
+</head>
+<body>
+<h1>Chunking Experiment Report</h1>
+<div class="summary">
+<p>{recommendation}</p>
+<p>All strategies were evaluated against local ChromaDB collections with provider, corpus, query set,
+and top-k held fixed. Only the chunking strategy and its parameters vary.</p>
+</div>
+<table>
+<thead>
+<tr><th>Strategy</th><th>Params</th><th>Chunks</th><th>Precision@k</th><th>Recall@k</th><th>MRR</th><th>Hit Rate@k</th><th>Local Collection</th></tr>
+</thead>
+<tbody>
+{body_rows}
+</tbody>
+</table>
+</body>
+</html>
+""",
+        encoding="utf-8",
+    )
+
+
+def mean(values: Iterable[float]) -> float:
+    items = list(values)
+    if not items:
+        return 0.0
+    return sum(items) / len(items)
+
+
+def _text_key(model_name: str, text: str) -> str:
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    return f"{model_name}:{digest}"
+
+
+def _params_hash(params: dict[str, Any]) -> str:
+    payload = json.dumps(params, sort_keys=True)
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()[:10]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/rag/chunking/__init__.py
+++ b/src/rag/chunking/__init__.py
@@ -1,0 +1,16 @@
+"""Chunking strategies for the RAG ingestion pipeline."""
+
+from rag.chunking.base import Chunker, ChunkResult
+from rag.chunking.field import FieldChunker
+from rag.chunking.fixed_size import FixedSizeChunker
+from rag.chunking.flat import FlatChunker
+from rag.chunking.sentence import SentenceChunker
+
+__all__ = [
+    "ChunkResult",
+    "Chunker",
+    "FieldChunker",
+    "FixedSizeChunker",
+    "FlatChunker",
+    "SentenceChunker",
+]

--- a/src/rag/chunking/base.py
+++ b/src/rag/chunking/base.py
@@ -1,0 +1,40 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+from rag.models.movie import Movie
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkResult:
+    """Text plus metadata emitted by a chunking strategy."""
+
+    text: str
+    chunk_index: int
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+class Chunker(ABC):
+    """Strategy interface for turning a movie record into embedding text chunks."""
+
+    @property
+    @abstractmethod
+    def strategy_name(self) -> str:
+        """Stable strategy identifier used in payloads and reports."""
+
+    @abstractmethod
+    def chunk(self, movie: Movie) -> list[ChunkResult]:
+        """Return embedding chunks for one movie."""
+
+
+def compact_lines(lines: list[tuple[str, str | int | list[str]]]) -> str:
+    """Render non-empty labeled fields into the flat text format used for embeddings."""
+    rendered: list[str] = []
+    for label, value in lines:
+        if isinstance(value, list):
+            text = ", ".join(item.strip() for item in value if item.strip())
+        else:
+            text = str(value).strip()
+        if text:
+            rendered.append(f"{label}: {text}")
+    return "\n".join(rendered)

--- a/src/rag/chunking/factory.py
+++ b/src/rag/chunking/factory.py
@@ -1,0 +1,28 @@
+from rag.chunking.base import Chunker
+from rag.chunking.field import FieldChunker
+from rag.chunking.fixed_size import FixedSizeChunker
+from rag.chunking.flat import FlatChunker
+from rag.chunking.sentence import SentenceChunker
+from rag.config import ChunkingStrategyName, settings
+
+
+def create_chunker(strategy: ChunkingStrategyName) -> Chunker:
+    if strategy == "flat":
+        return FlatChunker()
+    if strategy == "fixed_size":
+        return FixedSizeChunker(
+            chunk_size=settings.chunk_size,
+            overlap=settings.chunk_overlap,
+        )
+    if strategy == "sentence":
+        return SentenceChunker(
+            min_sentences=settings.chunk_min_sentences,
+            max_sentences=settings.chunk_max_sentences,
+        )
+    if strategy == "field":
+        return FieldChunker(settings.chunk_fields_list)
+    raise ValueError(f"Unsupported chunking strategy: {strategy}")
+
+
+def get_chunker() -> Chunker:
+    return create_chunker(settings.chunking_strategy)

--- a/src/rag/chunking/field.py
+++ b/src/rag/chunking/field.py
@@ -1,0 +1,54 @@
+from collections.abc import Iterable
+
+from rag.chunking.base import Chunker, ChunkResult, compact_lines
+from rag.models.movie import Movie
+
+SUPPORTED_FIELDS = {"plot", "cast", "metadata"}
+
+
+class FieldChunker(Chunker):
+    """Emit separate chunks for plot, cast, and metadata-oriented retrieval."""
+
+    def __init__(self, fields: Iterable[str] = ("plot", "cast", "metadata")) -> None:
+        normalized = [field.strip().lower() for field in fields if field.strip()]
+        unknown = sorted(set(normalized) - SUPPORTED_FIELDS)
+        if unknown:
+            raise ValueError(f"Unsupported field chunk(s): {', '.join(unknown)}")
+        if not normalized:
+            raise ValueError("fields must include at least one supported field.")
+        self.fields = tuple(dict.fromkeys(normalized))
+
+    @property
+    def strategy_name(self) -> str:
+        return "field"
+
+    def chunk(self, movie: Movie) -> list[ChunkResult]:
+        chunks: list[ChunkResult] = []
+        for field in self.fields:
+            text = self._field_text(movie, field)
+            if not text:
+                continue
+            chunks.append(
+                ChunkResult(
+                    text=text,
+                    chunk_index=len(chunks),
+                    payload={"chunk_field": field},
+                )
+            )
+        return chunks
+
+    def _field_text(self, movie: Movie, field: str) -> str:
+        if field == "plot":
+            return compact_lines([("Title", movie.title), ("Plot", movie.plot)])
+        if field == "cast":
+            return compact_lines([("Title", movie.title), ("Cast", movie.cast)])
+        if field == "metadata":
+            return compact_lines(
+                [
+                    ("Title", movie.title),
+                    ("Release Year", movie.release_year),
+                    ("Director", movie.director),
+                    ("Genre", movie.genre),
+                ]
+            )
+        raise ValueError(f"Unsupported field chunk: {field}")

--- a/src/rag/chunking/fixed_size.py
+++ b/src/rag/chunking/fixed_size.py
@@ -1,0 +1,50 @@
+from rag.chunking.base import Chunker, ChunkResult
+from rag.models.movie import Movie
+
+
+class FixedSizeChunker(Chunker):
+    """Split the flat movie text into whitespace-token windows with overlap."""
+
+    def __init__(self, chunk_size: int = 160, overlap: int = 32) -> None:
+        if chunk_size < 1:
+            raise ValueError("chunk_size must be at least 1.")
+        if overlap < 0:
+            raise ValueError("overlap must not be negative.")
+        if overlap >= chunk_size:
+            raise ValueError("overlap must be smaller than chunk_size.")
+        self.chunk_size = chunk_size
+        self.overlap = overlap
+
+    @property
+    def strategy_name(self) -> str:
+        return "fixed_size"
+
+    def chunk(self, movie: Movie) -> list[ChunkResult]:
+        from rag.chunking.flat import FlatChunker
+
+        tokens = FlatChunker().chunk(movie)[0].text.split()
+        if not tokens:
+            return []
+
+        chunks: list[ChunkResult] = []
+        step = self.chunk_size - self.overlap
+        start = 0
+        index = 0
+        while start < len(tokens):
+            window = tokens[start : start + self.chunk_size]
+            chunks.append(
+                ChunkResult(
+                    text=" ".join(window),
+                    chunk_index=index,
+                    payload={
+                        "chunk_size": self.chunk_size,
+                        "overlap": self.overlap,
+                        "token_start": start,
+                    },
+                )
+            )
+            start += step
+            if start + self.overlap >= len(tokens):
+                start = len(tokens)
+            index += 1
+        return chunks

--- a/src/rag/chunking/flat.py
+++ b/src/rag/chunking/flat.py
@@ -1,0 +1,23 @@
+from rag.chunking.base import Chunker, ChunkResult, compact_lines
+from rag.models.movie import Movie
+
+
+class FlatChunker(Chunker):
+    """Baseline strategy: one full movie text block per movie."""
+
+    @property
+    def strategy_name(self) -> str:
+        return "flat"
+
+    def chunk(self, movie: Movie) -> list[ChunkResult]:
+        text = compact_lines(
+            [
+                ("Title", movie.title),
+                ("Release Year", movie.release_year),
+                ("Director", movie.director),
+                ("Genre", movie.genre),
+                ("Cast", movie.cast),
+                ("Plot", movie.plot),
+            ]
+        )
+        return [ChunkResult(text=text, chunk_index=0)]

--- a/src/rag/chunking/sentence.py
+++ b/src/rag/chunking/sentence.py
@@ -1,0 +1,54 @@
+import re
+
+from rag.chunking.base import Chunker, ChunkResult, compact_lines
+from rag.models.movie import Movie
+
+_SENTENCE_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+class SentenceChunker(Chunker):
+    """Group plot sentences into natural-language windows."""
+
+    def __init__(self, min_sentences: int = 1, max_sentences: int = 4) -> None:
+        if min_sentences < 1:
+            raise ValueError("min_sentences must be at least 1.")
+        if max_sentences < min_sentences:
+            raise ValueError("max_sentences must be greater than or equal to min_sentences.")
+        self.min_sentences = min_sentences
+        self.max_sentences = max_sentences
+
+    @property
+    def strategy_name(self) -> str:
+        return "sentence"
+
+    def chunk(self, movie: Movie) -> list[ChunkResult]:
+        sentences = [part.strip() for part in _SENTENCE_RE.split(movie.plot) if part.strip()]
+        if not sentences:
+            return []
+
+        chunks: list[ChunkResult] = []
+        start = 0
+        while start < len(sentences):
+            end = min(start + self.max_sentences, len(sentences))
+            remaining = len(sentences) - end
+            if 0 < remaining < self.min_sentences:
+                end = len(sentences)
+            text = compact_lines(
+                [
+                    ("Title", movie.title),
+                    ("Plot", " ".join(sentences[start:end])),
+                ]
+            )
+            chunks.append(
+                ChunkResult(
+                    text=text,
+                    chunk_index=len(chunks),
+                    payload={
+                        "min_sentences": self.min_sentences,
+                        "max_sentences": self.max_sentences,
+                        "sentence_start": start,
+                    },
+                )
+            )
+            start = end
+        return chunks

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -13,6 +13,7 @@ EmbeddingProviderName = Literal[
     "google",
 ]
 VectorStoreName = Literal["qdrant", "chromadb", "pinecone", "pgvector"]
+ChunkingStrategyName = Literal["flat", "fixed_size", "sentence", "field"]
 
 DEFAULT_EMBEDDING_MODELS: dict[EmbeddingProviderName, str] = {
     "openai": "text-embedding-3-large",
@@ -125,6 +126,12 @@ class RAGConfig(BaseSettings):
     )
 
     batch_size: int = Field(100, validation_alias="BATCH_SIZE", ge=1, le=10_000)
+    chunking_strategy: ChunkingStrategyName = Field("flat", validation_alias="CHUNKING_STRATEGY")
+    chunk_size: int = Field(160, validation_alias="CHUNK_SIZE", ge=1)
+    chunk_overlap: int = Field(32, validation_alias="CHUNK_OVERLAP", ge=0)
+    chunk_min_sentences: int = Field(1, validation_alias="CHUNK_MIN_SENTENCES", ge=1)
+    chunk_max_sentences: int = Field(4, validation_alias="CHUNK_MAX_SENTENCES", ge=1)
+    chunk_fields: str = Field("plot,cast,metadata", validation_alias="CHUNK_FIELDS")
     validation_query: str = Field(
         DEFAULT_VALIDATION_QUERY,
         validation_alias="VALIDATION_QUERY",
@@ -167,6 +174,14 @@ class RAGConfig(BaseSettings):
         cleaned = value.strip()
         if not cleaned:
             raise ValueError("Value must not be empty.")
+        return cleaned
+
+    @field_validator("chunk_fields")
+    @classmethod
+    def _validate_chunk_fields(cls, value: str) -> str:
+        cleaned = ",".join(field.strip().lower() for field in value.split(",") if field.strip())
+        if not cleaned:
+            raise ValueError("CHUNK_FIELDS must include at least one field.")
         return cleaned
 
     @field_validator("vector_collection_prefix")
@@ -216,6 +231,14 @@ class RAGConfig(BaseSettings):
         if self.vector_store == "pgvector" and not self.pgvector_dsn:
             raise ValueError("PGVECTOR_DSN is required when VECTOR_STORE=pgvector.")
 
+        if self.chunk_overlap >= self.chunk_size:
+            raise ValueError("CHUNK_OVERLAP must be smaller than CHUNK_SIZE.")
+
+        if self.chunk_max_sentences < self.chunk_min_sentences:
+            raise ValueError(
+                "CHUNK_MAX_SENTENCES must be greater than or equal to CHUNK_MIN_SENTENCES."
+            )
+
         return self
 
     @property
@@ -224,6 +247,11 @@ class RAGConfig(BaseSettings):
         if self.embedding_dimension_override is not None:
             return self.embedding_dimension_override
         return infer_embedding_dimension(self.embedding_provider, self.embedding_model)
+
+    @property
+    def chunk_fields_list(self) -> list[str]:
+        """Return field chunk names parsed from CHUNK_FIELDS."""
+        return [field.strip() for field in self.chunk_fields.split(",") if field.strip()]
 
 
 settings = RAGConfig()

--- a/src/rag/ingestion/pipeline.py
+++ b/src/rag/ingestion/pipeline.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from tqdm import tqdm
 
+from rag.chunking.base import Chunker, ChunkResult
 from rag.config import settings
 from rag.embeddings.base import EmbeddingProvider
 from rag.ingestion import csv_loader
@@ -15,53 +16,63 @@ _OUTPUT_ENV_PATH = Path("ingestion-outputs.env")
 _REPORT_DIR = Path("outputs/reports")
 _COST_REPORT_PATH = _REPORT_DIR / "cost-report.json"
 _SKIPPED_MOVIES_REPORT_PATH = _REPORT_DIR / "skipped-movies.json"
+_CHUNK_ID_MULTIPLIER = 1_000_000
 
 
 def _embed_batch_with_fallback(
-    movies: list[Movie],
+    chunks: list[Movie],
     embedding_provider: EmbeddingProvider,
 ) -> tuple[list[Movie], list[list[float]], list[dict[str, Any]]]:
-    """Embed a batch, falling back to per-movie embedding when batch calls fail."""
+    """Embed a batch, falling back to per-chunk embedding when batch calls fail."""
     logger = get_logger(__name__)
-    vectors = embedding_provider.embed_batch([movie.plot for movie in movies])
+    vectors = embedding_provider.embed_batch([chunk.plot for chunk in chunks])
 
-    if len(vectors) == len(movies):
-        return movies, vectors, []
+    if len(vectors) == len(chunks):
+        return chunks, vectors, []
 
     logger.warning(
-        "Batch embedding returned %d vectors for %d movies. Falling back to per-movie embedding.",
+        "Batch embedding returned %d vectors for %d chunks. Falling back to per-chunk embedding.",
         len(vectors),
-        len(movies),
+        len(chunks),
     )
 
-    embedded_movies: list[Movie] = []
+    embedded_chunks: list[Movie] = []
     embedded_vectors: list[list[float]] = []
-    skipped_movies: list[dict[str, Any]] = []
-    for movie in movies:
-        vector = embedding_provider.embed(movie.plot)
+    skipped_chunks: list[dict[str, Any]] = []
+    for chunk in chunks:
+        vector = embedding_provider.embed(chunk.plot)
         if not vector:
-            skipped_movie = {
-                "id": movie.id,
-                "title": movie.title,
-                "release_year": movie.release_year,
-                "plot_chars": len(movie.plot),
+            skipped_chunk = {
+                "id": chunk.id,
+                "source_movie_id": chunk.source_movie_id,
+                "title": chunk.title,
+                "release_year": chunk.release_year,
+                "chunk_index": chunk.chunk_index,
+                "chunk_strategy": chunk.chunk_strategy,
+                "plot_chars": len(chunk.plot),
                 "reason": "embedding_failed_after_batch_fallback",
             }
             logger.error(
-                "Skipping movie id=%s title=%r because embedding failed. plot_chars=%d",
-                movie.id,
-                movie.title,
-                len(movie.plot),
+                "Skipping chunk id=%s source_movie_id=%s title=%r because embedding failed. "
+                "plot_chars=%d",
+                chunk.id,
+                chunk.source_movie_id,
+                chunk.title,
+                len(chunk.plot),
             )
-            skipped_movies.append(skipped_movie)
+            skipped_chunks.append(skipped_chunk)
             continue
-        embedded_movies.append(movie)
+        embedded_chunks.append(chunk)
         embedded_vectors.append(vector)
 
-    return embedded_movies, embedded_vectors, skipped_movies
+    return embedded_chunks, embedded_vectors, skipped_chunks
 
 
-def ingest_csv(embedding_provider: EmbeddingProvider, vector_store: VectorStore) -> None:
+def ingest_csv(
+    embedding_provider: EmbeddingProvider,
+    vector_store: VectorStore,
+    chunker: Chunker,
+) -> None:
     """Orchestrate the offline RAG ingestion pipeline."""
     logger = get_logger(__name__)
     logger.info("Initializing RAG ingestion pipeline")
@@ -73,47 +84,93 @@ def ingest_csv(embedding_provider: EmbeddingProvider, vector_store: VectorStore)
     batch_size = settings.batch_size
     model_info = embedding_provider.model_info
     target_name = vector_store.target_name(model_info)
+    chunks = _chunk_movies(movies, chunker)
+    if not chunks:
+        logger.warning("No chunks generated to ingest. Pipeline finished.")
+        return
 
     logger.info(
-        "Loaded %d movies. provider=%s model=%s target=%s",
+        "Loaded %d movies and generated %d chunks. provider=%s model=%s target=%s chunker=%s",
         len(movies),
+        len(chunks),
         settings.embedding_provider,
         model_info.name,
         target_name,
+        chunker.strategy_name,
     )
 
-    inserted_movie_count = 0
-    skipped_movies: list[dict[str, Any]] = []
-    for start in tqdm(range(0, len(movies), batch_size), desc="Ingesting Movies"):
-        batch = movies[start : start + batch_size]
-        embedded_movies, vectors, batch_skipped_movies = _embed_batch_with_fallback(
+    inserted_chunk_count = 0
+    skipped_chunks: list[dict[str, Any]] = []
+    for start in tqdm(range(0, len(chunks), batch_size), desc="Ingesting Movie Chunks"):
+        batch = chunks[start : start + batch_size]
+        embedded_chunks, vectors, batch_skipped_chunks = _embed_batch_with_fallback(
             batch, embedding_provider
         )
-        skipped_movies.extend(batch_skipped_movies)
+        skipped_chunks.extend(batch_skipped_chunks)
         if not vectors:
             logger.error(
                 "Failed to generate embeddings for batch %d. Skipping.", start // batch_size
             )
             continue
-        vector_store.upsert_batch(embedded_movies, vectors, model_info)
-        inserted_movie_count += len(embedded_movies)
+        vector_store.upsert_batch(embedded_chunks, vectors, model_info)
+        inserted_chunk_count += len(embedded_chunks)
 
     usage = embedding_provider.get_model_usage()
     logger.info("INGESTION COMPLETE")
     logger.info("Total Movies Processed : %d", len(movies))
-    logger.info("Total Movies Inserted  : %d", inserted_movie_count)
-    logger.info("Total Movies Skipped   : %d", len(skipped_movies))
+    logger.info("Total Chunks Generated : %d", len(chunks))
+    logger.info("Total Chunks Inserted  : %d", inserted_chunk_count)
+    logger.info("Total Chunks Skipped   : %d", len(skipped_chunks))
     logger.info("Total Prompt Tokens    : %d", usage.prompt_tokens)
     logger.info("Estimated USD Cost     : $%.5f", usage.estimated_cost_usd)
 
-    _write_ingestion_outputs(target_name, model_info.name, model_info.dimension, usage)
+    _write_ingestion_outputs(
+        target_name,
+        model_info.name,
+        model_info.dimension,
+        usage,
+        chunker.strategy_name,
+    )
     _write_skipped_movies_report(
         target_name=target_name,
         model_name=model_info.name,
         model_dimension=model_info.dimension,
         loaded_movie_count=len(movies),
-        inserted_movie_count=inserted_movie_count,
-        skipped_movies=skipped_movies,
+        generated_chunk_count=len(chunks),
+        inserted_chunk_count=inserted_chunk_count,
+        chunking_strategy=chunker.strategy_name,
+        skipped_chunks=skipped_chunks,
+    )
+
+
+def _chunk_movies(movies: list[Movie], chunker: Chunker) -> list[Movie]:
+    chunks: list[Movie] = []
+    for movie in movies:
+        movie_chunks = chunker.chunk(movie)
+        chunk_count = len(movie_chunks)
+        for chunk in movie_chunks:
+            chunks.append(_movie_from_chunk(movie, chunk, chunk_count, chunker.strategy_name))
+    return chunks
+
+
+def _movie_from_chunk(
+    movie: Movie,
+    chunk: ChunkResult,
+    chunk_count: int,
+    chunk_strategy: str,
+) -> Movie:
+    chunk_id = movie.id if chunk_count == 1 else movie.id * _CHUNK_ID_MULTIPLIER + chunk.chunk_index
+    chunk_field = chunk.payload.get("chunk_field")
+    return movie.model_copy(
+        update={
+            "id": chunk_id,
+            "plot": chunk.text,
+            "source_movie_id": movie.id,
+            "chunk_index": chunk.chunk_index,
+            "chunk_count": chunk_count,
+            "chunk_strategy": chunk_strategy,
+            "chunk_field": str(chunk_field) if chunk_field is not None else None,
+        }
     )
 
 
@@ -122,6 +179,7 @@ def _write_ingestion_outputs(
     model_name: str,
     dimension: int,
     usage: object,
+    chunking_strategy: str,
 ) -> None:
     """Persist CI-friendly ingestion outputs and cost report artifacts."""
     prompt_tokens = int(getattr(usage, "prompt_tokens", 0))
@@ -137,6 +195,7 @@ def _write_ingestion_outputs(
                 f"VECTOR_STORE={settings.vector_store}",
                 f"VECTOR_STORE_TARGET_NAME={target_name}",
                 f"VECTOR_COLLECTION_PREFIX={target_name}",
+                f"CHUNKING_STRATEGY={chunking_strategy}",
                 f"INGESTION_PROMPT_TOKENS={prompt_tokens}",
                 f"INGESTION_TOTAL_TOKENS={total_tokens}",
                 f"INGESTION_ESTIMATED_COST_USD={estimated_cost_usd:.8f}",
@@ -156,6 +215,7 @@ def _write_ingestion_outputs(
                 "vector_store": settings.vector_store,
                 "target_name": target_name,
                 "collection_name": target_name,
+                "chunking_strategy": chunking_strategy,
                 "prompt_tokens": prompt_tokens,
                 "total_tokens": total_tokens,
                 "estimated_cost_usd": estimated_cost_usd,
@@ -172,10 +232,12 @@ def _write_skipped_movies_report(
     model_name: str,
     model_dimension: int,
     loaded_movie_count: int,
-    inserted_movie_count: int,
-    skipped_movies: list[dict[str, Any]],
+    generated_chunk_count: int,
+    inserted_chunk_count: int,
+    chunking_strategy: str,
+    skipped_chunks: list[dict[str, Any]],
 ) -> None:
-    """Persist a machine-readable report for movies skipped during ingestion."""
+    """Persist a machine-readable report for chunks skipped during ingestion."""
     _REPORT_DIR.mkdir(parents=True, exist_ok=True)
     _SKIPPED_MOVIES_REPORT_PATH.write_text(
         json.dumps(
@@ -186,9 +248,11 @@ def _write_skipped_movies_report(
                 "vector_store": settings.vector_store,
                 "target_name": target_name,
                 "loaded_movie_count": loaded_movie_count,
-                "inserted_movie_count": inserted_movie_count,
-                "skipped_movie_count": len(skipped_movies),
-                "skipped_movies": skipped_movies,
+                "generated_chunk_count": generated_chunk_count,
+                "inserted_chunk_count": inserted_chunk_count,
+                "chunking_strategy": chunking_strategy,
+                "skipped_chunk_count": len(skipped_chunks),
+                "skipped_chunks": skipped_chunks,
             },
             indent=2,
         )

--- a/src/rag/main.py
+++ b/src/rag/main.py
@@ -1,3 +1,4 @@
+from rag.chunking.factory import get_chunker
 from rag.dataset import dataset
 from rag.embeddings.factory import get_embedding_provider
 from rag.ingestion import pipeline
@@ -11,15 +12,17 @@ logger = get_logger(__name__)
 def main() -> None:
     """Entrypoint for the offline RAG ingestion pipeline."""
     dataset.download_data()
+    chunker = get_chunker()
     embedding_provider = get_embedding_provider()
     vector_store = get_vector_store()
     logger.info(
-        "Starting ingestion with provider=%s model=%s vector_store=%s",
+        "Starting ingestion with provider=%s model=%s vector_store=%s chunker=%s",
         embedding_provider.__class__.__name__,
         embedding_provider.model_info.name,
         vector_store.__class__.__name__,
+        chunker.__class__.__name__,
     )
-    pipeline.ingest_csv(embedding_provider, vector_store)
+    pipeline.ingest_csv(embedding_provider, vector_store, chunker)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/rag/models/movie.py
+++ b/src/rag/models/movie.py
@@ -13,3 +13,10 @@ class Movie(BaseModel):
     genre: list[str] = Field(..., description="Movie genre")
     cast: list[str] = Field(..., description="Cast list")
     plot: str = Field(..., description="Detailed plot description used for embedding")
+    source_movie_id: int | None = Field(
+        None, description="Original movie identifier when this record represents a chunk"
+    )
+    chunk_index: int | None = Field(None, description="Zero-based chunk index")
+    chunk_count: int | None = Field(None, description="Total chunks emitted for the source movie")
+    chunk_strategy: str | None = Field(None, description="Chunking strategy that produced the text")
+    chunk_field: str | None = Field(None, description="Source field for field-based chunks")

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,0 +1,158 @@
+from typing import cast
+
+import pytest
+
+from rag.chunking.base import compact_lines
+from rag.chunking.factory import create_chunker, get_chunker
+from rag.chunking.field import FieldChunker
+from rag.chunking.fixed_size import FixedSizeChunker
+from rag.chunking.flat import FlatChunker
+from rag.chunking.sentence import SentenceChunker
+from rag.config import ChunkingStrategyName, settings
+from rag.models.movie import Movie
+
+
+@pytest.fixture
+def movie() -> Movie:
+    return Movie(
+        id=3,
+        title="Chunk Movie",
+        release_year=1999,
+        director="Director",
+        genre=["Sci-Fi", "Adventure"],
+        cast=["Actor One", "Actor Two"],
+        plot="First sentence. Second sentence! Third sentence? Fourth sentence. Fifth sentence.",
+    )
+
+
+def test_compact_lines_skips_empty_values() -> None:
+    assert compact_lines([("Title", "Movie"), ("Cast", []), ("Plot", " Text ")]) == (
+        "Title: Movie\nPlot: Text"
+    )
+
+
+def test_flat_chunker_emits_single_full_movie_chunk(movie: Movie) -> None:
+    chunks = FlatChunker().chunk(movie)
+
+    assert len(chunks) == 1
+    assert chunks[0].chunk_index == 0
+    assert "Title: Chunk Movie" in chunks[0].text
+    assert "Cast: Actor One, Actor Two" in chunks[0].text
+    assert "Plot: First sentence." in chunks[0].text
+
+
+def test_fixed_size_chunker_windows_with_overlap(movie: Movie) -> None:
+    chunker = FixedSizeChunker(chunk_size=6, overlap=2)
+    chunks = chunker.chunk(movie)
+
+    assert chunker.strategy_name == "fixed_size"
+    assert len(chunks) > 1
+    assert chunks[0].payload == {"chunk_size": 6, "overlap": 2, "token_start": 0}
+    assert chunks[1].payload["token_start"] == 4
+
+
+def test_fixed_size_chunker_rejects_invalid_parameters() -> None:
+    with pytest.raises(ValueError, match="chunk_size must be at least 1"):
+        FixedSizeChunker(chunk_size=0)
+    with pytest.raises(ValueError, match="overlap must not be negative"):
+        FixedSizeChunker(chunk_size=5, overlap=-1)
+    with pytest.raises(ValueError, match="overlap must be smaller"):
+        FixedSizeChunker(chunk_size=5, overlap=5)
+
+
+def test_fixed_size_chunker_handles_empty_text(movie: Movie) -> None:
+    empty_movie = movie.model_copy(
+        update={
+            "title": "",
+            "release_year": "",
+            "director": "",
+            "genre": [],
+            "cast": [],
+            "plot": "",
+        }
+    )
+    assert FixedSizeChunker().chunk(empty_movie) == []
+
+
+def test_field_chunker_emits_requested_fields(movie: Movie) -> None:
+    chunker = FieldChunker(["plot", "cast", "metadata"])
+    chunks = chunker.chunk(movie)
+
+    assert chunker.strategy_name == "field"
+    assert [chunk.payload["chunk_field"] for chunk in chunks] == ["plot", "cast", "metadata"]
+    assert (
+        chunks[0].text
+        == "Title: Chunk Movie\nPlot: First sentence. Second sentence! Third sentence? Fourth sentence. Fifth sentence."
+    )
+    assert chunks[1].text == "Title: Chunk Movie\nCast: Actor One, Actor Two"
+    assert "Director: Director" in chunks[2].text
+
+
+def test_field_chunker_rejects_invalid_fields() -> None:
+    with pytest.raises(ValueError, match="Unsupported field"):
+        FieldChunker(["plot", "unknown"])
+    with pytest.raises(ValueError, match="at least one"):
+        FieldChunker([])
+
+
+def test_field_chunker_rejects_unknown_private_dispatch(movie: Movie) -> None:
+    with pytest.raises(ValueError, match="Unsupported field chunk"):
+        FieldChunker(["plot"])._field_text(movie, "unknown")
+
+
+def test_field_chunker_skips_empty_field_text(movie: Movie) -> None:
+    empty_plot_movie = movie.model_copy(update={"title": "", "plot": ""})
+    assert FieldChunker(["plot"]).chunk(empty_plot_movie) == []
+
+
+def test_sentence_chunker_groups_sentence_windows(movie: Movie) -> None:
+    chunker = SentenceChunker(min_sentences=2, max_sentences=2)
+    chunks = chunker.chunk(movie)
+
+    assert chunker.strategy_name == "sentence"
+    assert [chunk.chunk_index for chunk in chunks] == [0, 1]
+    assert chunks[0].payload == {
+        "min_sentences": 2,
+        "max_sentences": 2,
+        "sentence_start": 0,
+    }
+    assert chunks[-1].text.endswith("Fifth sentence.")
+
+
+def test_sentence_chunker_keeps_full_windows_without_short_tail_merge(movie: Movie) -> None:
+    chunks = SentenceChunker(min_sentences=1, max_sentences=2).chunk(movie)
+    assert [chunk.chunk_index for chunk in chunks] == [0, 1, 2]
+
+
+def test_sentence_chunker_rejects_invalid_parameters() -> None:
+    with pytest.raises(ValueError, match="min_sentences must be at least 1"):
+        SentenceChunker(min_sentences=0)
+    with pytest.raises(ValueError, match="greater than or equal"):
+        SentenceChunker(min_sentences=3, max_sentences=2)
+
+
+def test_sentence_chunker_handles_empty_plot(movie: Movie) -> None:
+    assert SentenceChunker().chunk(movie.model_copy(update={"plot": ""})) == []
+
+
+def test_create_chunker(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "chunk_size", 10)
+    monkeypatch.setattr(settings, "chunk_overlap", 2)
+    monkeypatch.setattr(settings, "chunk_min_sentences", 2)
+    monkeypatch.setattr(settings, "chunk_max_sentences", 3)
+    monkeypatch.setattr(settings, "chunk_fields", "plot,cast")
+
+    assert isinstance(create_chunker("flat"), FlatChunker)
+    assert isinstance(create_chunker("fixed_size"), FixedSizeChunker)
+    assert isinstance(create_chunker("sentence"), SentenceChunker)
+    assert isinstance(create_chunker("field"), FieldChunker)
+
+
+def test_create_chunker_rejects_unknown_strategy() -> None:
+    with pytest.raises(ValueError, match="Unsupported chunking strategy"):
+        create_chunker(cast(ChunkingStrategyName, "unknown"))
+
+
+def test_get_chunker_uses_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "chunking_strategy", "flat")
+    assert isinstance(get_chunker(), FlatChunker)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -77,6 +77,48 @@ def test_embedding_dimension_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.embedding_dimension == 1536
 
 
+def test_chunking_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
+    config = RAGConfig()
+
+    assert config.chunking_strategy == "flat"
+    assert config.chunk_fields_list == ["plot", "cast", "metadata"]
+
+
+def test_chunk_fields_are_normalized(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
+    monkeypatch.setenv("CHUNK_FIELDS", " Plot, Cast ,, Metadata ")
+    config = RAGConfig()
+
+    assert config.chunk_fields == "plot,cast,metadata"
+
+
+def test_chunk_fields_rejects_empty_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
+    monkeypatch.setenv("CHUNK_FIELDS", " , ")
+
+    with pytest.raises(ValueError, match="CHUNK_FIELDS must include"):
+        RAGConfig()
+
+
+def test_chunk_overlap_must_be_smaller_than_size(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
+    monkeypatch.setenv("CHUNK_SIZE", "8")
+    monkeypatch.setenv("CHUNK_OVERLAP", "8")
+
+    with pytest.raises(ValueError, match="CHUNK_OVERLAP must be smaller"):
+        RAGConfig()
+
+
+def test_chunk_sentence_bounds_are_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    apply_base_env(monkeypatch)
+    monkeypatch.setenv("CHUNK_MIN_SENTENCES", "4")
+    monkeypatch.setenv("CHUNK_MAX_SENTENCES", "3")
+
+    with pytest.raises(ValueError, match="CHUNK_MAX_SENTENCES must be"):
+        RAGConfig()
+
+
 def test_shape_validator_requires_provider_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
     apply_base_env(monkeypatch)
     monkeypatch.setenv("EMBEDDING_PROVIDER", "openai")

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -5,9 +5,21 @@ import pandas as pd
 import pytest
 
 import rag.ingestion.pipeline as pipeline_module
+from rag.chunking.base import Chunker, ChunkResult
+from rag.chunking.field import FieldChunker
+from rag.chunking.flat import FlatChunker
 from rag.ingestion.csv_loader import load_movies
 from rag.ingestion.pipeline import ingest_csv
 from rag.models.movie import Movie
+
+
+class EmptyChunker(Chunker):
+    @property
+    def strategy_name(self) -> str:
+        return "empty"
+
+    def chunk(self, movie: Movie) -> list[ChunkResult]:
+        return []
 
 
 def test_load_movies_success(tmp_path: Path) -> None:
@@ -87,9 +99,13 @@ def test_ingest_csv_success() -> None:
     )
 
     with patch("rag.ingestion.csv_loader.load_movies", return_value=[mock_movie]):
-        ingest_csv(mock_provider, mock_store)
+        ingest_csv(mock_provider, mock_store, FlatChunker())
 
     mock_provider.embed_batch.assert_called_once()
+    embedded_texts = mock_provider.embed_batch.call_args.args[0]
+    assert embedded_texts == [
+        "Title: Test Movie\nRelease Year: 2000\nDirector: D\nGenre: G\nCast: C\nPlot: Some plot"
+    ]
     mock_store.upsert_batch.assert_called_once()
 
 
@@ -100,9 +116,32 @@ def test_ingest_csv_no_movies() -> None:
     mock_store.target_name.return_value = "movies_test_model_3"
 
     with patch("rag.ingestion.csv_loader.load_movies", return_value=[]):
-        ingest_csv(mock_provider, mock_store)
+        ingest_csv(mock_provider, mock_store, FlatChunker())
 
     mock_provider.embed_batch.assert_not_called()
+
+
+def test_ingest_csv_no_chunks() -> None:
+    mock_provider = MagicMock()
+    mock_provider.model_info.name = "test-model"
+    mock_provider.model_info.dimension = 3
+    mock_store = MagicMock()
+    mock_store.target_name.return_value = "movies_test_model_3"
+    mock_movie = Movie(
+        id=1,
+        title="T",
+        release_year=2000,
+        director="D",
+        genre=["G"],
+        cast=["C"],
+        plot="P",
+    )
+
+    with patch("rag.ingestion.csv_loader.load_movies", return_value=[mock_movie]):
+        ingest_csv(mock_provider, mock_store, EmptyChunker())
+
+    mock_provider.embed_batch.assert_not_called()
+    mock_store.upsert_batch.assert_not_called()
 
 
 def test_ingest_csv_embedding_failure() -> None:
@@ -132,7 +171,7 @@ def test_ingest_csv_embedding_failure() -> None:
     )
 
     with patch("rag.ingestion.csv_loader.load_movies", return_value=[mock_movie]):
-        ingest_csv(mock_provider, mock_store)
+        ingest_csv(mock_provider, mock_store, FlatChunker())
 
     mock_store.upsert_batch.assert_not_called()
 
@@ -174,12 +213,20 @@ def test_ingest_csv_falls_back_to_per_movie_embedding() -> None:
     mock_store.target_name.return_value = "movies_test_model_3"
 
     with patch("rag.ingestion.csv_loader.load_movies", return_value=[movie_one, movie_two]):
-        ingest_csv(mock_provider, mock_store)
+        ingest_csv(mock_provider, mock_store, FlatChunker())
 
-    mock_provider.embed_batch.assert_called_once_with(["First plot", "Second plot"])
+    mock_provider.embed_batch.assert_called_once_with(
+        [
+            "Title: First\nRelease Year: 2000\nDirector: D1\nGenre: G1\nCast: C1\nPlot: First plot",
+            "Title: Second\nRelease Year: 2001\nDirector: D2\nGenre: G2\nCast: C2\nPlot: Second plot",
+        ]
+    )
     assert mock_provider.embed.call_count == 2
+    inserted_chunk = mock_store.upsert_batch.call_args.args[0][0]
+    assert inserted_chunk.source_movie_id == 1
+    assert inserted_chunk.chunk_strategy == "flat"
     mock_store.upsert_batch.assert_called_once_with(
-        [movie_one],
+        [inserted_chunk],
         [[0.1, 0.2, 0.3]],
         mock_provider.model_info,
     )
@@ -235,10 +282,53 @@ def test_ingest_csv_writes_skipped_movies_report(
     )
 
     with patch("rag.ingestion.csv_loader.load_movies", return_value=[movie_one, movie_two]):
-        ingest_csv(mock_provider, mock_store)
+        ingest_csv(mock_provider, mock_store, FlatChunker())
 
     report = (report_dir / "skipped-movies.json").read_text(encoding="utf-8")
-    assert '"skipped_movie_count": 1' in report
+    assert '"skipped_chunk_count": 1' in report
     assert '"id": 2' in report
     assert '"title": "Second"' in report
+    assert '"chunking_strategy": "flat"' in report
     assert '"reason": "embedding_failed_after_batch_fallback"' in report
+
+
+def test_ingest_csv_expands_field_chunks() -> None:
+    mock_provider = MagicMock()
+    mock_provider.model_info.name = "test-model"
+    mock_provider.model_info.dimension = 3
+    mock_provider.embed_batch.return_value = [
+        [0.1, 0.2, 0.3],
+        [0.4, 0.5, 0.6],
+    ]
+
+    mock_usage = MagicMock()
+    mock_usage.prompt_tokens = 10
+    mock_usage.total_tokens = 10
+    mock_usage.estimated_cost_usd = 0.0
+    mock_provider.get_model_usage.return_value = mock_usage
+
+    mock_store = MagicMock()
+    mock_store.target_name.return_value = "movies_test_model_3"
+
+    movie = Movie(
+        id=7,
+        title="Field Test",
+        release_year=2001,
+        director="Director",
+        genre=["Drama"],
+        cast=["Actor One", "Actor Two"],
+        plot="A plot",
+    )
+
+    with patch("rag.ingestion.csv_loader.load_movies", return_value=[movie]):
+        ingest_csv(mock_provider, mock_store, FieldChunker(["plot", "cast"]))
+
+    embedded_texts = mock_provider.embed_batch.call_args.args[0]
+    assert embedded_texts == [
+        "Title: Field Test\nPlot: A plot",
+        "Title: Field Test\nCast: Actor One, Actor Two",
+    ]
+    inserted_chunks = mock_store.upsert_batch.call_args.args[0]
+    assert [chunk.chunk_field for chunk in inserted_chunks] == ["plot", "cast"]
+    assert [chunk.source_movie_id for chunk in inserted_chunks] == [7, 7]
+    assert [chunk.id for chunk in inserted_chunks] == [7_000_000, 7_000_001]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,7 @@ from rag.main import main
 def test_main_uses_factories() -> None:
     with (
         patch("rag.main.dataset.download_data"),
+        patch("rag.main.get_chunker") as get_chunker,
         patch("rag.main.get_embedding_provider") as get_provider,
         patch("rag.main.get_vector_store") as get_store,
         patch("rag.main.pipeline.ingest_csv") as ingest_csv,
@@ -16,6 +17,9 @@ def test_main_uses_factories() -> None:
 
         main()
 
+        get_chunker.assert_called_once()
         get_provider.assert_called_once()
         get_store.assert_called_once()
-        ingest_csv.assert_called_once_with(provider, get_store.return_value)
+        ingest_csv.assert_called_once_with(
+            provider, get_store.return_value, get_chunker.return_value
+        )


### PR DESCRIPTION
## Summary

Implements issue #8 / parent issue aharbii/movie-finder#31 as a time-boxed chunking experiment framework.

- Adds a `rag.chunking` strategy interface with flat, fixed-size, sentence, and field-based chunkers.
- Wires ingestion to receive an explicit chunker dependency, with `CHUNKING_STRATEGY=flat` as the default to preserve current full-movie embedding behavior.
- Adds a local ChromaDB-only `scripts/chunking_experiment.py` sweep harness that keeps provider, corpus, query set, and top-k fixed while varying chunking strategy.
- Emits CSV and HTML experiment reports to identify the highest-MRR candidate before any production Qdrant deployment.
- Documents the workflow, adoption gate, and generated artifact policy.

## Validation

- `make test-coverage` passed with 158 tests and 100.00% line/branch coverage.
- `make check` passed: ruff, mypy, and coverage gate.
- Commit pre-commit hooks passed, including detect-secrets, mypy, and ruff.

## Notes

Generated experiment outputs are ignored under `experiments/`. Production adoption still requires coordinating query-time retrieval behavior with `chain/`, especially if field-based chunking wins the experiment.